### PR TITLE
Rusty API for Fennel CLI

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,18 @@
 #[cfg(test)]
 mod tests;
 
-pub mod wf_buffer;
-pub mod wf_codec;
-pub mod wf_core;
-pub mod wf_models;
+mod wf_buffer;
+mod wf_codec;
+mod wf_core;
+mod wf_models;
+
+pub fn encode_from_json<T: AsRef<str>>(json: T) -> Result<String, String> {
+    let message: wf_models::WhiteflagMessage =
+        serde_json::from_str(json.as_ref()).expect("deserialization error");
+    let values: Vec<String> = message.try_into()?;
+    Ok(wf_core::creator::encode(&values))
+}
+
+pub fn decode_from_hex<T: AsRef<str>>(hex: T) -> Result<String, String> {
+    Ok(String::from(hex.as_ref()))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,5 +14,7 @@ pub fn encode_from_json<T: AsRef<str>>(json: T) -> Result<String, String> {
 }
 
 pub fn decode_from_hex<T: AsRef<str>>(hex: T) -> Result<String, String> {
-    Ok(String::from(hex.as_ref()))
+    let message = wf_core::creator::decode(hex);
+    let json = serde_json::to_string(&message).expect("serialization issue");
+    Ok(json)
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,5 @@
-use crate::wf_core::message::WhiteflagMessage;
+use crate::{decode_from_hex, wf_core::message::WhiteflagMessage};
+use serde_json::json;
 
 #[cfg(test)]
 #[test]
@@ -60,7 +61,30 @@ fn test_compile_auth_message() {
 }
 
 #[test]
-fn test_serialize_auth_message() {}
+fn test_serialize_auth_message() {
+    let hex = "5746313020800000000000000000000000000000000000000000000000000000000000000000b43a3a38399d1797b7b933b0b734b9b0ba34b7b71734b73a17bbb434ba32b33630b380";
+
+    let json = json!({
+        "prefix": "WF",
+        "version": "1",
+        "encryptionIndicator": "0",
+        "duressIndicator": "0",
+        "messageCode": 'A',
+        "referenceIndicator": "0",
+        "referencedMessage": "0000000000000000000000000000000000000000000000000000000000000000",
+        "verificationMethod": "1",
+        "verificationData": "https://organisation.int/whiteflag"
+    })
+    .to_string();
+
+    test_json(&json, &decode_from_hex(hex).unwrap());
+}
+
+fn test_json(actual: &str, expected: &str) {
+    let a = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(actual).unwrap();
+    let e = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(expected).unwrap();
+    assert_eq!(a, e);
+}
 
 #[test]
 fn test_deserialize_auth_message() {}

--- a/src/wf_core/basic_message.rs
+++ b/src/wf_core/basic_message.rs
@@ -1,3 +1,4 @@
+use super::field::Field;
 use super::wf_buffer::common::append_bits;
 use super::{segment::MessageSegment, types::MessageType};
 
@@ -54,5 +55,12 @@ impl BasicMessage {
             .get(fieldname.as_ref())
             .or(self.body.get(fieldname.as_ref()))
             .or(None)
+    }
+
+    pub fn get_fields(&self) -> Vec<&Field> {
+        let mut fields: Vec<&Field> = vec![];
+        fields.extend(&self.header.fields);
+        fields.extend(&self.body.fields);
+        fields
     }
 }

--- a/src/wf_core/message_tests.rs
+++ b/src/wf_core/message_tests.rs
@@ -1,5 +1,5 @@
 use super::creator::{decode, encode};
-use crate::wf_models::{AuthenticationMessage, MessageHeader, WhiteflagEncodeCompatible};
+use crate::wf_models::{AuthenticationMessage, MessageHeader};
 
 #[test]
 fn encode_sign_signal_message() {
@@ -141,7 +141,7 @@ fn decode_sign_signal_message() {
 fn encode_auth_message() {
     let encoding_result: String = "5746313020800000000000000000000000000000000000000000000000000000000000000000b43a3a38399d1797b7b933b0b734b9b0ba34b7b71734b73a17bbb434ba32b33630b380".to_string();
 
-    let auth_message = AuthenticationMessage {
+    let auth_message: Vec<String> = AuthenticationMessage {
         header: MessageHeader {
             prefix: String::from("WF"),
             version: String::from("1"),
@@ -155,11 +155,12 @@ fn encode_auth_message() {
         },
         verification_method: String::from("1"),
         verification_data: String::from("https://organisation.int/whiteflag"),
-    };
+    }
+    .into();
 
     assert_eq!(
         encoding_result,
-        encode(&auth_message.to_field_values()),
+        encode(&auth_message),
         "Encoding should be correct"
     );
 }

--- a/src/wf_core/message_tests.rs
+++ b/src/wf_core/message_tests.rs
@@ -1,5 +1,5 @@
 use super::creator::{decode, encode};
-use crate::wf_models::{AuthenticationMessage, MessageHeader};
+use crate::wf_models::{AuthenticationMessage, MessageHeader, WhiteflagEncodeCompatible};
 
 #[test]
 fn encode_sign_signal_message() {

--- a/src/wf_core/message_tests.rs
+++ b/src/wf_core/message_tests.rs
@@ -1,5 +1,5 @@
 use super::creator::{decode, encode};
-use crate::wf_models::AuthenticationMessage;
+use crate::wf_models::{AuthenticationMessage, MessageHeader};
 
 #[test]
 fn encode_sign_signal_message() {
@@ -142,15 +142,17 @@ fn encode_auth_message() {
     let encoding_result: String = "5746313020800000000000000000000000000000000000000000000000000000000000000000b43a3a38399d1797b7b933b0b734b9b0ba34b7b71734b73a17bbb434ba32b33630b380".to_string();
 
     let auth_message = AuthenticationMessage {
-        prefix: String::from("WF"),
-        version: String::from("1"),
-        encryption_indicator: String::from("0"),
-        duress_indicator: String::from("0"),
-        message_code: String::from("A"),
-        reference_indicator: String::from("0"),
-        referenced_message: String::from(
-            "0000000000000000000000000000000000000000000000000000000000000000",
-        ),
+        header: MessageHeader {
+            prefix: String::from("WF"),
+            version: String::from("1"),
+            encryption_indicator: String::from("0"),
+            duress_indicator: String::from("0"),
+            message_code: 'A',
+            reference_indicator: String::from("0"),
+            referenced_message: String::from(
+                "0000000000000000000000000000000000000000000000000000000000000000",
+            ),
+        },
         verification_method: String::from("1"),
         verification_data: String::from("https://organisation.int/whiteflag"),
     };

--- a/src/wf_core/types.rs
+++ b/src/wf_core/types.rs
@@ -3,7 +3,7 @@ use super::field::Field;
 use super::segment::MessageSegment;
 
 pub struct MessageType {
-    message_code: char,
+    pub message_code: char,
     pub headers: MessageSegment,
     pub body: MessageSegment,
 }

--- a/src/wf_models/authentication.rs
+++ b/src/wf_models/authentication.rs
@@ -1,4 +1,4 @@
-use super::{MessageHeader, WhiteflagEncodeCompatible, WhiteflagMessage};
+use super::{MessageHeader, WhiteflagMessage};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -10,34 +10,42 @@ pub struct AuthenticationMessage {
     pub verification_data: String,
 }
 
-impl From<WhiteflagMessage> for AuthenticationMessage {
-    fn from(message: WhiteflagMessage) -> Self {
-        AuthenticationMessage {
-            header: message.header,
-            verification_method: message
+impl TryFrom<WhiteflagMessage> for AuthenticationMessage {
+    type Error = String;
+
+    fn try_from(value: WhiteflagMessage) -> Result<Self, Self::Error> {
+        if value.header.message_code != 'A' {
+            return Err(format!(
+                "not possible to convert message code {} to authentication message",
+                &value.header.message_code
+            ));
+        }
+
+        Ok(AuthenticationMessage {
+            header: value.header,
+            verification_method: value
                 .body
                 .get("verificationMethod")
-                .unwrap()
+                .expect("missing verificationMethod")
                 .as_str()
-                .unwrap()
-                .to_owned(),
-            verification_data: message
+                .expect("unable to convert to string")
+                .to_string(),
+            verification_data: value
                 .body
                 .get("verificationData")
-                .unwrap()
+                .expect("missing verificationData")
                 .as_str()
-                .unwrap()
-                .to_owned(),
-        }
+                .expect("unable to convert to string")
+                .to_string(),
+        })
     }
 }
 
-impl WhiteflagEncodeCompatible for AuthenticationMessage {
-    fn to_field_values(self) -> Vec<String> {
-        [
-            self.header.to_field_values(),
-            vec![self.verification_method, self.verification_data],
-        ]
-        .concat()
+impl From<AuthenticationMessage> for Vec<String> {
+    fn from(message: AuthenticationMessage) -> Self {
+        let auth_values = vec![message.verification_method, message.verification_data];
+        let mut values: Vec<String> = message.header.into();
+        values.extend(auth_values.into_iter());
+        values
     }
 }

--- a/src/wf_models/authentication.rs
+++ b/src/wf_models/authentication.rs
@@ -1,0 +1,43 @@
+use super::{MessageHeader, WhiteflagEncodeCompatible, WhiteflagMessage};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all(deserialize = "camelCase"))]
+pub struct AuthenticationMessage {
+    #[serde(flatten)]
+    pub header: MessageHeader,
+    pub verification_method: String,
+    pub verification_data: String,
+}
+
+impl From<WhiteflagMessage> for AuthenticationMessage {
+    fn from(message: WhiteflagMessage) -> Self {
+        AuthenticationMessage {
+            header: message.header,
+            verification_method: message
+                .body
+                .get("verificationMethod")
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_owned(),
+            verification_data: message
+                .body
+                .get("verificationData")
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_owned(),
+        }
+    }
+}
+
+impl WhiteflagEncodeCompatible for AuthenticationMessage {
+    fn to_field_values(self) -> Vec<String> {
+        [
+            self.header.to_field_values(),
+            vec![self.verification_method, self.verification_data],
+        ]
+        .concat()
+    }
+}

--- a/src/wf_models/header.rs
+++ b/src/wf_models/header.rs
@@ -1,4 +1,3 @@
-use super::WhiteflagEncodeCompatible;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -13,16 +12,16 @@ pub struct MessageHeader {
     pub referenced_message: String,
 }
 
-impl WhiteflagEncodeCompatible for MessageHeader {
-    fn to_field_values(self) -> Vec<String> {
+impl From<MessageHeader> for Vec<String> {
+    fn from(message: MessageHeader) -> Self {
         vec![
-            self.prefix,
-            self.version,
-            self.encryption_indicator,
-            self.duress_indicator,
-            self.message_code.to_string(),
-            self.reference_indicator,
-            self.referenced_message,
+            message.prefix,
+            message.version,
+            message.encryption_indicator,
+            message.duress_indicator,
+            message.message_code.to_string(),
+            message.reference_indicator,
+            message.referenced_message,
         ]
     }
 }

--- a/src/wf_models/header.rs
+++ b/src/wf_models/header.rs
@@ -1,0 +1,28 @@
+use super::WhiteflagEncodeCompatible;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all(deserialize = "camelCase"))]
+pub struct MessageHeader {
+    pub prefix: String,
+    pub version: String,
+    pub encryption_indicator: String,
+    pub duress_indicator: String,
+    pub message_code: char,
+    pub reference_indicator: String,
+    pub referenced_message: String,
+}
+
+impl WhiteflagEncodeCompatible for MessageHeader {
+    fn to_field_values(self) -> Vec<String> {
+        vec![
+            self.prefix,
+            self.version,
+            self.encryption_indicator,
+            self.duress_indicator,
+            self.message_code.to_string(),
+            self.reference_indicator,
+            self.referenced_message,
+        ]
+    }
+}

--- a/src/wf_models/mod.rs
+++ b/src/wf_models/mod.rs
@@ -7,6 +7,7 @@ mod test;
 
 mod authentication;
 mod header;
+mod serialize;
 
 pub use authentication::AuthenticationMessage;
 pub use header::MessageHeader;

--- a/src/wf_models/mod.rs
+++ b/src/wf_models/mod.rs
@@ -20,22 +20,18 @@ pub struct WhiteflagMessage {
     pub body: HashMap<String, Value>,
 }
 
-// implicit trait syntax dyn T
-impl WhiteflagMessage {
-    pub fn from_json<T: AsRef<str>>(json: T) -> WhiteflagMessage {
-        let wf_message: WhiteflagMessage = serde_json::from_str(json.as_ref()).unwrap();
-        wf_message
-    }
+impl TryFrom<WhiteflagMessage> for Vec<String> {
+    type Error = String;
 
-    pub fn to_field_values(self) -> Result<Vec<String>, String> {
-        match &self.header.message_code {
+    fn try_from(message: WhiteflagMessage) -> Result<Self, Self::Error> {
+        let values: Vec<String> = match &message.header.message_code {
             'A' => {
-                let auth: AuthenticationMessage = self.try_into()?;
-                return Ok(auth.into());
+                let auth: AuthenticationMessage = message.try_into()?;
+                auth.into()
             }
-            _ => {}
+            _ => vec![],
         };
 
-        Ok(vec![])
+        Ok(values)
     }
 }

--- a/src/wf_models/mod.rs
+++ b/src/wf_models/mod.rs
@@ -20,27 +20,22 @@ pub struct WhiteflagMessage {
     pub body: HashMap<String, Value>,
 }
 
-pub trait WhiteflagEncodeCompatible {
-    fn to_field_values(self) -> Vec<String>;
-}
-
+// implicit trait syntax dyn T
 impl WhiteflagMessage {
     pub fn from_json<T: AsRef<str>>(json: T) -> WhiteflagMessage {
         let wf_message: WhiteflagMessage = serde_json::from_str(json.as_ref()).unwrap();
         wf_message
     }
-}
 
-impl WhiteflagEncodeCompatible for WhiteflagMessage {
-    fn to_field_values(self) -> Vec<String> {
+    pub fn to_field_values(self) -> Result<Vec<String>, String> {
         match &self.header.message_code {
             'A' => {
-                let auth: AuthenticationMessage = self.into();
-                return auth.to_field_values();
+                let auth: AuthenticationMessage = self.try_into()?;
+                return Ok(auth.into());
             }
             _ => {}
         };
 
-        vec![]
+        Ok(vec![])
     }
 }

--- a/src/wf_models/mod.rs
+++ b/src/wf_models/mod.rs
@@ -36,6 +36,7 @@ impl WhiteflagEncodeCompatible for WhiteflagMessage {
         match &self.header.message_code {
             'A' => {
                 let auth: AuthenticationMessage = self.into();
+                return auth.to_field_values();
             }
             _ => {}
         };

--- a/src/wf_models/mod.rs
+++ b/src/wf_models/mod.rs
@@ -5,17 +5,11 @@ use std::collections::HashMap;
 #[cfg(test)]
 mod test;
 
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all(deserialize = "camelCase"))]
-pub struct MessageHeader {
-    pub prefix: String,
-    pub version: String,
-    pub encryption_indicator: String,
-    pub duress_indicator: String,
-    pub message_code: char,
-    pub reference_indicator: String,
-    pub referenced_message: String,
-}
+mod authentication;
+mod header;
+
+pub use authentication::AuthenticationMessage;
+pub use header::MessageHeader;
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all(deserialize = "camelCase"))]
@@ -26,44 +20,26 @@ pub struct WhiteflagMessage {
     pub body: HashMap<String, Value>,
 }
 
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all(deserialize = "camelCase"))]
-pub struct AuthenticationMessage {
-    #[serde(flatten)]
-    pub header: MessageHeader,
-    pub verification_method: String,
-    pub verification_data: String,
-}
-
-impl MessageHeader {
-    pub fn to_field_values(self) -> Vec<String> {
-        vec![
-            self.prefix,
-            self.version,
-            self.encryption_indicator,
-            self.duress_indicator,
-            self.message_code.to_string(),
-            self.reference_indicator,
-            self.referenced_message,
-        ]
-    }
-}
-
-impl AuthenticationMessage {
-    pub fn to_field_values(self) -> Vec<String> {
-        [
-            self.header.to_field_values(),
-            vec![self.verification_method, self.verification_data],
-        ]
-        .concat()
-    }
+pub trait WhiteflagEncodeCompatible {
+    fn to_field_values(self) -> Vec<String>;
 }
 
 impl WhiteflagMessage {
-    pub fn to_wf_message(&self) {
+    pub fn from_json<T: AsRef<str>>(json: T) -> WhiteflagMessage {
+        let wf_message: WhiteflagMessage = serde_json::from_str(json.as_ref()).unwrap();
+        wf_message
+    }
+}
+
+impl WhiteflagEncodeCompatible for WhiteflagMessage {
+    fn to_field_values(self) -> Vec<String> {
         match &self.header.message_code {
-            'A' => {}
+            'A' => {
+                let auth: AuthenticationMessage = self.into();
+            }
             _ => {}
-        }
+        };
+
+        vec![]
     }
 }

--- a/src/wf_models/mod.rs
+++ b/src/wf_models/mod.rs
@@ -1,46 +1,69 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
 
 #[cfg(test)]
 mod test;
 
-/* #[derive(Serialize, Deserialize)]
-pub struct HeaderSegment {
-    prefix: String,
-    version: String,
-    encryption_indicator: String,
-    duress_indicator: String,
-    message_code: String,
-    reference_indicator: String,
-    referenced_message: String,
-} */
-
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all(deserialize = "camelCase"))]
-pub struct AuthenticationMessage {
+pub struct MessageHeader {
     pub prefix: String,
     pub version: String,
     pub encryption_indicator: String,
     pub duress_indicator: String,
-    pub message_code: String,
+    pub message_code: char,
     pub reference_indicator: String,
     pub referenced_message: String,
+}
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all(deserialize = "camelCase"))]
+pub struct WhiteflagMessage {
+    #[serde(flatten)]
+    pub header: MessageHeader,
+    #[serde(flatten)]
+    pub body: HashMap<String, Value>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all(deserialize = "camelCase"))]
+pub struct AuthenticationMessage {
+    #[serde(flatten)]
+    pub header: MessageHeader,
     pub verification_method: String,
     pub verification_data: String,
 }
 
-impl AuthenticationMessage {
+impl MessageHeader {
     pub fn to_field_values(self) -> Vec<String> {
         vec![
             self.prefix,
             self.version,
             self.encryption_indicator,
             self.duress_indicator,
-            self.message_code,
+            self.message_code.to_string(),
             self.reference_indicator,
             self.referenced_message,
-            self.verification_method,
-            self.verification_data,
         ]
+    }
+}
+
+impl AuthenticationMessage {
+    pub fn to_field_values(self) -> Vec<String> {
+        [
+            self.header.to_field_values(),
+            vec![self.verification_method, self.verification_data],
+        ]
+        .concat()
+    }
+}
+
+impl WhiteflagMessage {
+    pub fn to_wf_message(&self) {
+        match &self.header.message_code {
+            'A' => {}
+            _ => {}
+        }
     }
 }

--- a/src/wf_models/serialize.rs
+++ b/src/wf_models/serialize.rs
@@ -32,6 +32,28 @@ fn name_map(name: &str) -> &'static str {
         /* authentication */
         "VerificationMethod" => "verificationMethod",
         "VerificationData" => "verificationData",
+        /* crypto */
+        "CryptoDataType" => "cryptoDataType",
+        "CryptoData" => "cryptoData",
+        /* free text */
+        "Text" => "text",
+        /* resource */
+        "ResourceMethod" => "resourceMethod",
+        "ResourceData" => "resourceData",
+        /* test */
+        "PseudoMessageCode" => "pseudoMessageCode",
+        /* sign signal */
+        "SubjectCode" => "subjectCode",
+        "DateTime" => "dateTime",
+        "Duration" => "duration",
+        "ObjectType" => "objectType",
+        "ObjectLatitude" => "objectLatitude",
+        "ObjectLongitude" => "objectLongitude",
+        "ObjectSizeDim1" => "objectSizeDim1",
+        "ObjectSizeDim2" => "objectSizeDim2",
+        "ObjectOrientation" => "objectOrientation",
+        /* request */
+        "ObjectTypeQuant" => "objectTypeQuant",
         _ => "",
     }
 }

--- a/src/wf_models/serialize.rs
+++ b/src/wf_models/serialize.rs
@@ -1,0 +1,37 @@
+use crate::wf_core::basic_message::BasicMessage;
+use serde::ser::{Serialize, SerializeStruct, Serializer};
+
+impl Serialize for BasicMessage {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let fields = self.get_fields();
+        let length = fields.len();
+
+        let mut state = serializer.serialize_struct("BasicMessage", length)?;
+
+        for f in fields {
+            state.serialize_field(name_map(&f.name), f.get())?;
+        }
+
+        state.end()
+    }
+}
+
+fn name_map(name: &str) -> &'static str {
+    match name {
+        /* headers */
+        "Prefix" => "prefix",
+        "Version" => "version",
+        "EncryptionIndicator" => "encryptionIndicator",
+        "DuressIndicator" => "duressIndicator",
+        "MessageCode" => "messageCode",
+        "ReferenceIndicator" => "referenceIndicator",
+        "ReferencedMessage" => "referencedMessage",
+        /* authentication */
+        "VerificationMethod" => "verificationMethod",
+        "VerificationData" => "verificationData",
+        _ => "",
+    }
+}

--- a/src/wf_models/test.rs
+++ b/src/wf_models/test.rs
@@ -86,7 +86,7 @@ fn serialize_message() {
         verification_data
     );
 
-    let wf_message: WhiteflagMessage = serde_json::from_str(&json).unwrap();
+    let wf_message: AuthenticationMessage = WhiteflagMessage::from_json(&json).into();
 
     assert_eq!(prefix, wf_message.header.prefix);
     assert_eq!(version, wf_message.header.version);
@@ -95,12 +95,6 @@ fn serialize_message() {
     assert_eq!(message_code, wf_message.header.message_code.to_string());
     assert_eq!(reference_indicator, wf_message.header.reference_indicator);
     assert_eq!(referenced_message, wf_message.header.referenced_message);
-    assert_eq!(
-        verification_method,
-        wf_message.body.get("verificationMethod").unwrap()
-    );
-    assert_eq!(
-        verification_data,
-        wf_message.body.get("verificationData").unwrap()
-    );
+    assert_eq!(verification_method, wf_message.verification_method);
+    assert_eq!(verification_data, wf_message.verification_data);
 }

--- a/src/wf_models/test.rs
+++ b/src/wf_models/test.rs
@@ -6,7 +6,7 @@ fn serialize_authentication_message() {
     let version = "1";
     let encryption_indicator = "0";
     let duress_indicator = "0";
-    let message_code = "A";
+    let message_code = 'A';
     let reference_indicator = "0";
     let referenced_message = "0000000000000000000000000000000000000000000000000000000000000000";
     let verification_method = "1";
@@ -44,7 +44,7 @@ fn serialize_authentication_message() {
         auth_message.header.encryption_indicator
     );
     assert_eq!(duress_indicator, auth_message.header.duress_indicator);
-    assert_eq!(message_code, auth_message.header.message_code.to_string());
+    assert_eq!(message_code, auth_message.header.message_code);
     assert_eq!(reference_indicator, auth_message.header.reference_indicator);
     assert_eq!(referenced_message, auth_message.header.referenced_message);
     assert_eq!(verification_method, auth_message.verification_method);
@@ -57,7 +57,7 @@ fn serialize_message() {
     let version = "1";
     let encryption_indicator = "0";
     let duress_indicator = "0";
-    let message_code = "A";
+    let message_code = 'A';
     let reference_indicator = "0";
     let referenced_message = "0000000000000000000000000000000000000000000000000000000000000000";
     let verification_method = "1";
@@ -92,7 +92,7 @@ fn serialize_message() {
     assert_eq!(version, wf_message.header.version);
     assert_eq!(encryption_indicator, wf_message.header.encryption_indicator);
     assert_eq!(duress_indicator, wf_message.header.duress_indicator);
-    assert_eq!(message_code, wf_message.header.message_code.to_string());
+    assert_eq!(message_code, wf_message.header.message_code);
     assert_eq!(reference_indicator, wf_message.header.reference_indicator);
     assert_eq!(referenced_message, wf_message.header.referenced_message);
     assert_eq!(verification_method, wf_message.verification_method);

--- a/src/wf_models/test.rs
+++ b/src/wf_models/test.rs
@@ -1,4 +1,4 @@
-use super::{AuthenticationMessage, WhiteflagMessage};
+use super::{AuthenticationMessage, WhiteflagMessage, WhiteflagEncodeCompatible};
 
 #[test]
 fn serialize_authentication_message() {
@@ -97,4 +97,52 @@ fn serialize_message() {
     assert_eq!(referenced_message, wf_message.header.referenced_message);
     assert_eq!(verification_method, wf_message.verification_method);
     assert_eq!(verification_data, wf_message.verification_data);
+}
+
+#[test]
+fn serialize_message_into_values() {
+    let prefix = "WF";
+    let version = "1";
+    let encryption_indicator = "0";
+    let duress_indicator = "0";
+    let message_code = 'A';
+    let reference_indicator = "0";
+    let referenced_message = "0000000000000000000000000000000000000000000000000000000000000000";
+    let verification_method = "1";
+    let verification_data = "https://organisation.int/whiteflag";
+
+    let json = format!(
+        r#"{{
+        "prefix": "{}",
+        "version": "{}",
+        "encryptionIndicator": "{}",
+        "duressIndicator": "{}",
+        "messageCode": "{}",
+        "referenceIndicator": "{}",
+        "referencedMessage": "{}",
+        "verificationMethod": "{}",
+        "verificationData": "{}"
+    }}"#,
+        prefix,
+        version,
+        encryption_indicator,
+        duress_indicator,
+        message_code,
+        reference_indicator,
+        referenced_message,
+        verification_method,
+        verification_data
+    );
+
+    let values = WhiteflagMessage::from_json(&json).to_field_values();
+
+    assert_eq!(prefix, values[0]);
+    assert_eq!(version, values[1]);
+    assert_eq!(encryption_indicator, values[2]);
+    assert_eq!(duress_indicator, values[3]);
+    assert_eq!(message_code.to_string(), values[4]);
+    assert_eq!(reference_indicator, values[5]);
+    assert_eq!(referenced_message, values[6]);
+    assert_eq!(verification_method, values[7]);
+    assert_eq!(verification_data, values[8]);
 }

--- a/src/wf_models/test.rs
+++ b/src/wf_models/test.rs
@@ -1,4 +1,5 @@
 use super::{AuthenticationMessage, WhiteflagMessage};
+use serde_json::json;
 
 #[test]
 fn serialize_authentication_message() {
@@ -12,28 +13,18 @@ fn serialize_authentication_message() {
     let verification_method = "1";
     let verification_data = "https://organisation.int/whiteflag";
 
-    let json = format!(
-        r#"{{
-        "prefix": "{}",
-        "version": "{}",
-        "encryptionIndicator": "{}",
-        "duressIndicator": "{}",
-        "messageCode": "{}",
-        "referenceIndicator": "{}",
-        "referencedMessage": "{}",
-        "verificationMethod": "{}",
-        "verificationData": "{}"
-    }}"#,
-        prefix,
-        version,
-        encryption_indicator,
-        duress_indicator,
-        message_code,
-        reference_indicator,
-        referenced_message,
-        verification_method,
-        verification_data
-    );
+    let json = json!({
+        "prefix": prefix,
+        "version": version,
+        "encryptionIndicator": encryption_indicator,
+        "duressIndicator": duress_indicator,
+        "messageCode": message_code,
+        "referenceIndicator": reference_indicator,
+        "referencedMessage": referenced_message,
+        "verificationMethod": verification_method,
+        "verificationData": verification_data
+    })
+    .to_string();
 
     let auth_message: AuthenticationMessage = serde_json::from_str(&json).unwrap();
 
@@ -63,28 +54,18 @@ fn serialize_message() {
     let verification_method = "1";
     let verification_data = "https://organisation.int/whiteflag";
 
-    let json = format!(
-        r#"{{
-        "prefix": "{}",
-        "version": "{}",
-        "encryptionIndicator": "{}",
-        "duressIndicator": "{}",
-        "messageCode": "{}",
-        "referenceIndicator": "{}",
-        "referencedMessage": "{}",
-        "verificationMethod": "{}",
-        "verificationData": "{}"
-    }}"#,
-        prefix,
-        version,
-        encryption_indicator,
-        duress_indicator,
-        message_code,
-        reference_indicator,
-        referenced_message,
-        verification_method,
-        verification_data
-    );
+    let json = json!({
+        "prefix": prefix,
+        "version": version,
+        "encryptionIndicator": encryption_indicator,
+        "duressIndicator": duress_indicator,
+        "messageCode": message_code,
+        "referenceIndicator": reference_indicator,
+        "referencedMessage": referenced_message,
+        "verificationMethod": verification_method,
+        "verificationData": verification_data
+    })
+    .to_string();
 
     let message: WhiteflagMessage = serde_json::from_str(&json).unwrap();
     let wf_message: AuthenticationMessage = message.try_into().unwrap();
@@ -112,28 +93,18 @@ fn serialize_message_into_values() {
     let verification_method = "1";
     let verification_data = "https://organisation.int/whiteflag";
 
-    let json = format!(
-        r#"{{
-        "prefix": "{}",
-        "version": "{}",
-        "encryptionIndicator": "{}",
-        "duressIndicator": "{}",
-        "messageCode": "{}",
-        "referenceIndicator": "{}",
-        "referencedMessage": "{}",
-        "verificationMethod": "{}",
-        "verificationData": "{}"
-    }}"#,
-        prefix,
-        version,
-        encryption_indicator,
-        duress_indicator,
-        message_code,
-        reference_indicator,
-        referenced_message,
-        verification_method,
-        verification_data
-    );
+    let json = json!({
+        "prefix": prefix,
+        "version": version,
+        "encryptionIndicator": encryption_indicator,
+        "duressIndicator": duress_indicator,
+        "messageCode": message_code,
+        "referenceIndicator": reference_indicator,
+        "referencedMessage": referenced_message,
+        "verificationMethod": verification_method,
+        "verificationData": verification_data
+    })
+    .to_string();
 
     let message: WhiteflagMessage = serde_json::from_str(&json).unwrap();
     let values: Vec<String> = message.try_into().unwrap();

--- a/src/wf_models/test.rs
+++ b/src/wf_models/test.rs
@@ -1,7 +1,7 @@
-use super::AuthenticationMessage;
+use super::{AuthenticationMessage, WhiteflagMessage};
 
 #[test]
-fn serialize() {
+fn serialize_authentication_message() {
     let prefix = "WF";
     let version = "1";
     let encryption_indicator = "0";
@@ -37,13 +37,70 @@ fn serialize() {
 
     let auth_message: AuthenticationMessage = serde_json::from_str(&json).unwrap();
 
-    assert_eq!(prefix, auth_message.prefix);
-    assert_eq!(version, auth_message.version);
-    assert_eq!(encryption_indicator, auth_message.encryption_indicator);
-    assert_eq!(duress_indicator, auth_message.duress_indicator);
-    assert_eq!(message_code, auth_message.message_code);
-    assert_eq!(reference_indicator, auth_message.reference_indicator);
-    assert_eq!(referenced_message, auth_message.referenced_message);
+    assert_eq!(prefix, auth_message.header.prefix);
+    assert_eq!(version, auth_message.header.version);
+    assert_eq!(
+        encryption_indicator,
+        auth_message.header.encryption_indicator
+    );
+    assert_eq!(duress_indicator, auth_message.header.duress_indicator);
+    assert_eq!(message_code, auth_message.header.message_code.to_string());
+    assert_eq!(reference_indicator, auth_message.header.reference_indicator);
+    assert_eq!(referenced_message, auth_message.header.referenced_message);
     assert_eq!(verification_method, auth_message.verification_method);
     assert_eq!(verification_data, auth_message.verification_data);
+}
+
+#[test]
+fn serialize_message() {
+    let prefix = "WF";
+    let version = "1";
+    let encryption_indicator = "0";
+    let duress_indicator = "0";
+    let message_code = "A";
+    let reference_indicator = "0";
+    let referenced_message = "0000000000000000000000000000000000000000000000000000000000000000";
+    let verification_method = "1";
+    let verification_data = "https://organisation.int/whiteflag";
+
+    let json = format!(
+        r#"{{
+        "prefix": "{}",
+        "version": "{}",
+        "encryptionIndicator": "{}",
+        "duressIndicator": "{}",
+        "messageCode": "{}",
+        "referenceIndicator": "{}",
+        "referencedMessage": "{}",
+        "verificationMethod": "{}",
+        "verificationData": "{}"
+    }}"#,
+        prefix,
+        version,
+        encryption_indicator,
+        duress_indicator,
+        message_code,
+        reference_indicator,
+        referenced_message,
+        verification_method,
+        verification_data
+    );
+
+    let wf_message: WhiteflagMessage = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(prefix, wf_message.header.prefix);
+    assert_eq!(version, wf_message.header.version);
+    assert_eq!(encryption_indicator, wf_message.header.encryption_indicator);
+    assert_eq!(duress_indicator, wf_message.header.duress_indicator);
+    assert_eq!(message_code, wf_message.header.message_code.to_string());
+    assert_eq!(reference_indicator, wf_message.header.reference_indicator);
+    assert_eq!(referenced_message, wf_message.header.referenced_message);
+    assert_eq!(
+        verification_method,
+        wf_message.body.get("verificationMethod").unwrap()
+    );
+    assert_eq!(
+        verification_data,
+        wf_message.body.get("verificationData").unwrap()
+    );
 }

--- a/src/wf_models/test.rs
+++ b/src/wf_models/test.rs
@@ -86,7 +86,8 @@ fn serialize_message() {
         verification_data
     );
 
-    let wf_message: AuthenticationMessage = WhiteflagMessage::from_json(&json).try_into().unwrap();
+    let message: WhiteflagMessage = serde_json::from_str(&json).unwrap();
+    let wf_message: AuthenticationMessage = message.try_into().unwrap();
 
     assert_eq!(prefix, wf_message.header.prefix);
     assert_eq!(version, wf_message.header.version);
@@ -134,9 +135,8 @@ fn serialize_message_into_values() {
         verification_data
     );
 
-    let values = WhiteflagMessage::from_json(&json)
-        .to_field_values()
-        .unwrap();
+    let message: WhiteflagMessage = serde_json::from_str(&json).unwrap();
+    let values: Vec<String> = message.try_into().unwrap();
 
     assert_eq!(prefix, values[0]);
     assert_eq!(version, values[1]);

--- a/src/wf_models/test.rs
+++ b/src/wf_models/test.rs
@@ -1,4 +1,4 @@
-use super::{AuthenticationMessage, WhiteflagMessage, WhiteflagEncodeCompatible};
+use super::{AuthenticationMessage, WhiteflagMessage};
 
 #[test]
 fn serialize_authentication_message() {
@@ -86,7 +86,7 @@ fn serialize_message() {
         verification_data
     );
 
-    let wf_message: AuthenticationMessage = WhiteflagMessage::from_json(&json).into();
+    let wf_message: AuthenticationMessage = WhiteflagMessage::from_json(&json).try_into().unwrap();
 
     assert_eq!(prefix, wf_message.header.prefix);
     assert_eq!(version, wf_message.header.version);
@@ -134,7 +134,9 @@ fn serialize_message_into_values() {
         verification_data
     );
 
-    let values = WhiteflagMessage::from_json(&json).to_field_values();
+    let values = WhiteflagMessage::from_json(&json)
+        .to_field_values()
+        .unwrap();
 
     assert_eq!(prefix, values[0]);
     assert_eq!(version, values[1]);


### PR DESCRIPTION
`encode` & `decode` are working for authentication messages -- still needs a bit more work, but the overall API is set so I figured I can do the rest of the work in a different PR