### PR TITLE
Field value refactor

### DIFF
--- a/src/wf_convert/mod.rs
+++ b/src/wf_convert/mod.rs
@@ -53,12 +53,13 @@ fn set_all<T: FieldValue>(
                 throw new WfCoreException("Field " + field.debugInfo() + " already set or array item " + index + " contains invalid data: " + data[index], null);
             } */
             let value = &data[index];
-            let mut field = Field::from_definition(f, None);
-            match field.set(value.as_ref()) {
-                Ok(_) => println!("Message field set successfully."),
+            let field = match f.set(value.as_ref()) {
+                Ok(field) => {
+                    println!("Message field set successfully.");
+                    field
+                },
                 Err(e) => panic!("{:?}", e),
-            }
-
+            };
             index += 1;
             field
         })

--- a/src/wf_field/codec_tests.rs
+++ b/src/wf_field/codec_tests.rs
@@ -1,4 +1,4 @@
-use super::field::Field;
+use super::{Field, FieldDefinition};
 use crate::{
     wf_buffer::common::{decode_from_hexadecimal, to_hex},
     wf_codec::encoding::*,
@@ -8,12 +8,12 @@ const FIELDNAME: &str = "TESTFIELD";
 
 #[test]
 fn utf_encoding() {
-    let mut field = Field::new(FIELDNAME, None, UTF8, 0, -1);
-    field.set("WF").unwrap();
+    let def = FieldDefinition::new(FIELDNAME, None, UTF8, 0, -1);
+    let field = def.set("WF").unwrap();
 
     assert_eq!(
         "5746",
-        to_hex(&field.encode().expect("tried encoding empty field")),
+        to_hex(&field.encode()),
         "UTF-8 field should be correctly hexadecimal encoded"
     );
     assert_eq!(
@@ -30,30 +30,27 @@ fn utf_encoding() {
 
 #[test]
 fn utf_decoding() {
-    let mut field = Field::new(FIELDNAME, None, UTF8, 0, -1);
+    let def = FieldDefinition::new(FIELDNAME, None, UTF8, 0, -1);
     let (buffer, _) = decode_from_hexadecimal("5746");
     let result = "WF";
 
+    let actual: String = def.decode(buffer).into();
+
     assert_eq!(
         result,
-        field.decode(buffer),
+        actual,
         "UTF-8 field should be correctly decoded"
-    );
-    assert_eq!(
-        result,
-        field.get().as_ref().expect("no value was set"),
-        "UTF-8 decoded field value should be correctly set"
     );
 }
 
 #[test]
 fn bin_encoding_1() {
-    let mut field = Field::new(FIELDNAME, None, BIN, 0, 8);
-    field.set("10111011").unwrap();
+    let bin = FieldDefinition::new(FIELDNAME, None, BIN, 0, 8);
+    let field = bin.set("10111011").unwrap();
 
     assert_eq!(
         "bb",
-        to_hex(&field.encode().expect("tried encoding empty field")),
+        to_hex(&field.encode()),
         "Binary field should be correctly binary encoded"
     );
     assert_eq!(
@@ -70,30 +67,27 @@ fn bin_encoding_1() {
 
 #[test]
 fn bin_decoding_1() {
-    let mut field = Field::new(FIELDNAME, None, BIN, 1, 7);
+    let def = FieldDefinition::new(FIELDNAME, None, BIN, 1, 7);
     let (buffer, _) = decode_from_hexadecimal("aa");
     let result = "101010";
 
+    let actual: String = def.decode(buffer).into();
+
     assert_eq!(
         result,
-        field.decode(buffer),
+        actual,
         "Binary field should be correctly decoded"
-    );
-    assert_eq!(
-        result,
-        field.get().as_ref().expect("no value was set"),
-        "Binary decoded field value should be correctly set"
     );
 }
 
 #[test]
 fn bin_encoding_2() {
-    let mut field = Field::new(FIELDNAME, None, BIN, 4, 5);
-    field.set("1").unwrap();
+    let bin = FieldDefinition::new(FIELDNAME, None, BIN, 4, 5);
+    let field = bin.set("1").unwrap();
 
     assert_eq!(
         "80",
-        to_hex(&field.encode().expect("tried encoding empty field")),
+        to_hex(&field.encode()),
         "Binary field should be correctly binary encoded"
     );
     assert_eq!(
@@ -110,48 +104,42 @@ fn bin_encoding_2() {
 
 #[test]
 fn bin_decoding_2_a() {
-    let mut field = Field::new(FIELDNAME, None, BIN, 4, 5);
+    let def = FieldDefinition::new(FIELDNAME, None, BIN, 4, 5);
     let (buffer, _) = decode_from_hexadecimal("80");
     let result = "1";
 
+    let actual: String = def.decode(buffer).into();
+
     assert_eq!(
         result,
-        field.decode(buffer),
+        actual,
         "Binary field should be correctly decoded"
-    );
-    assert_eq!(
-        result,
-        field.get().as_ref().expect("no value was set"),
-        "Binary decoded field value should be correctly set"
     );
 }
 
 #[test]
 fn bin_decoding_2_b() {
-    let mut field = Field::new(FIELDNAME, None, BIN, 2, 3);
+    let def = FieldDefinition::new(FIELDNAME, None, BIN, 2, 3);
     let (buffer, _) = decode_from_hexadecimal("7f");
     let result = "0";
 
+    let actual: String = def.decode(buffer).into();
+
     assert_eq!(
         result,
-        field.decode(buffer),
+        actual,
         "Binary field should be correctly decoded"
-    );
-    assert_eq!(
-        result,
-        field.get().as_ref().expect("no value was set"),
-        "Binary decoded field value should be correctly set"
     );
 }
 
 #[test]
 fn dec_encoding() {
-    let mut field = Field::new(FIELDNAME, None, DEC, 0, 3);
-    field.set("1230").unwrap();
+    let mut dec = FieldDefinition::new(FIELDNAME, None, DEC, 0, 3);
+    let field = dec.set("1230").unwrap();
 
     assert_eq!(
         "1230",
-        to_hex(&field.encode().expect("tried encoding empty field")),
+        to_hex(&field.encode()),
         "Decimal field should be correctly binary encoded"
     );
     assert_eq!(
@@ -168,30 +156,27 @@ fn dec_encoding() {
 
 #[test]
 fn dec_decoding() {
-    let mut field = Field::new(FIELDNAME, None, DEC, 0, 3);
+    let def = FieldDefinition::new(FIELDNAME, None, DEC, 0, 3);
     let (buffer, _) = decode_from_hexadecimal("1234");
     let result = "123";
 
+    let actual: String = def.decode(buffer).into();
+
     assert_eq!(
         result,
-        field.decode(buffer),
+        actual,
         "Decimal field should be correctly decoded"
-    );
-    assert_eq!(
-        result,
-        field.get().as_ref().expect("no value was set"),
-        "Decimal decoded field value should be correctly set"
     );
 }
 
 #[test]
 fn hex_encoding() {
-    let mut field = Field::new(FIELDNAME, None, HEX, 0, 2);
-    field.set("3f").unwrap();
+    let hex = FieldDefinition::new(FIELDNAME, None, HEX, 0, 2);
+    let field = hex.set("3f").unwrap();
 
     assert_eq!(
         "3f",
-        to_hex(&field.encode().expect("tried encoding empty field")),
+        to_hex(&field.encode()),
         "Hexadecimal field should be correctly binary encoded"
     );
     assert_eq!(
@@ -208,30 +193,27 @@ fn hex_encoding() {
 
 #[test]
 fn hex_decoding() {
-    let mut field = Field::new(FIELDNAME, None, HEX, 0, 2);
+    let def = FieldDefinition::new(FIELDNAME, None, HEX, 0, 2);
     let (buffer, _) = decode_from_hexadecimal("0x3f");
     let result = "3f";
 
+    let actual: String = def.decode(buffer).into();
+
     assert_eq!(
         result,
-        field.decode(buffer),
+        actual,
         "Hexadecimal field should be correctly decoded"
-    );
-    assert_eq!(
-        result,
-        field.get().as_ref().expect("no value was set"),
-        "Hexadecimal decoded field value should be correctly set"
     );
 }
 
 #[test]
 fn datetime_encoding() {
-    let mut field = Field::new(FIELDNAME, None, DATETIME, 0, -1);
-    field.set("2020-07-01T21:42:23Z").unwrap();
+    let datetime = FieldDefinition::new(FIELDNAME, None, DATETIME, 0, -1);
+    let field = datetime.set("2020-07-01T21:42:23Z").unwrap();
 
     assert_eq!(
         "20200701214223",
-        to_hex(&field.encode().expect("tried encoding empty field")),
+        to_hex(&field.encode()),
         "DateTime field should be correctly binary encoded"
     );
     assert_eq!(
@@ -248,30 +230,27 @@ fn datetime_encoding() {
 
 #[test]
 fn datetime_decoding() {
-    let mut field = Field::new(FIELDNAME, None, DATETIME, 0, -1);
+    let def = FieldDefinition::new(FIELDNAME, None, DATETIME, 0, -1);
     let (buffer, _) = decode_from_hexadecimal("20200701214223");
     let result = "2020-07-01T21:42:23Z";
 
+    let actual: String = def.decode(buffer).into();
+
     assert_eq!(
         result,
-        field.decode(buffer),
+        actual,
         "DateTime field should be correctly decoded"
-    );
-    assert_eq!(
-        result,
-        field.get().as_ref().expect("no value was set"),
-        "DateTime decoded field value should be correctly set"
     );
 }
 
 #[test]
 fn duration_encoding() {
-    let mut field = Field::new(FIELDNAME, None, DURATION, 0, 10);
-    field.set("P24D11H30M").unwrap();
+    let duration = FieldDefinition::new(FIELDNAME, None, DURATION, 0, 10);
+    let field = duration.set("P24D11H30M").unwrap();
 
     assert_eq!(
         "241130",
-        to_hex(&field.encode().expect("tried encoding empty field")),
+        to_hex(&field.encode()),
         "Duration field should be correctly binary encoded"
     );
     assert_eq!(
@@ -288,30 +267,27 @@ fn duration_encoding() {
 
 #[test]
 fn duration_decoding() {
-    let mut field = Field::new(FIELDNAME, None, DURATION, 0, 10);
+    let def = FieldDefinition::new(FIELDNAME, None, DURATION, 0, 10);
     let (buffer, _) = decode_from_hexadecimal("241130");
     let result = "P24D11H30M";
 
+    let actual: String = def.decode(buffer).into();
+
     assert_eq!(
         result,
-        field.decode(buffer),
+        actual,
         "Duration field should be correctly decoded"
-    );
-    assert_eq!(
-        result,
-        field.get().as_ref().expect("no value was set"),
-        "Duration decoded field value should be correctly set"
     );
 }
 
 #[test]
 fn latitude_encoding() {
-    let mut field = Field::new(FIELDNAME, None, LAT, 0, 9);
-    field.set("+23.34244").unwrap(); // 1001 0001 1001 1010 0001 0010 0010 0000
+    let lat = FieldDefinition::new(FIELDNAME, None, LAT, 0, 9);
+    let field = lat.set("+23.34244").unwrap(); // 1001 0001 1001 1010 0001 0010 0010 0000
 
     assert_eq!(
         "919a1220",
-        to_hex(&field.encode().expect("tried encoding empty field")),
+        to_hex(&field.encode()),
         "Latitude field should be correctly binary encoded"
     );
     assert_eq!(
@@ -328,30 +304,27 @@ fn latitude_encoding() {
 
 #[test]
 fn latitude_decoding() {
-    let mut field = Field::new(FIELDNAME, None, LAT, 0, 9);
+    let def = FieldDefinition::new(FIELDNAME, None, LAT, 0, 9);
     let (buffer, _) = decode_from_hexadecimal("919a1220");
     let result = "+23.34244";
 
+    let actual: String = def.decode(buffer).into();
+
     assert_eq!(
         result,
-        field.decode(buffer),
+        actual,
         "Latitude field should be correctly decoded"
-    );
-    assert_eq!(
-        result,
-        field.get().as_ref().expect("no value was set"),
-        "Latitude decoded field value should be correctly set"
     );
 }
 
 #[test]
 fn longitude_encoding() {
-    let mut field = Field::new(FIELDNAME, None, LONG, 0, 10);
-    field.set("-163.34245").unwrap(); // 0000 1011 0001 1001 1010 0001 0010 0010 1000
+    let long = FieldDefinition::new(FIELDNAME, None, LONG, 0, 10);
+    let field = long.set("-163.34245").unwrap(); // 0000 1011 0001 1001 1010 0001 0010 0010 1000
 
     assert_eq!(
         "0b19a12280",
-        to_hex(&field.encode().expect("tried encoding empty field")),
+        to_hex(&field.encode()),
         "Longitude field should be correctly binary encoded"
     );
     assert_eq!(
@@ -368,36 +341,30 @@ fn longitude_encoding() {
 
 #[test]
 fn longitude_decoding_1() {
-    let mut field = Field::new(FIELDNAME, None, LONG, 0, 10);
+    let def = FieldDefinition::new(FIELDNAME, None, LONG, 0, 10);
     let (buffer, _) = decode_from_hexadecimal("8b19a12380");
     let result = "+163.34247";
 
+    let actual: String = def.decode(buffer).into();
+
     assert_eq!(
         result,
-        field.decode(buffer),
+        actual,
         "Longitude field should be correctly decoded"
-    );
-    assert_eq!(
-        result,
-        field.get().as_ref().expect("no value was set"),
-        "Longitude decoded field value should be correctly set"
     );
 }
 
 #[test]
 fn longitude_decoding_2() {
-    let mut field = Field::new(FIELDNAME, None, LONG, 0, 10);
+    let def = FieldDefinition::new(FIELDNAME, None, LONG, 0, 10);
     let (buffer, _) = decode_from_hexadecimal("0319a12380");
     let result = "-063.34247";
 
+    let actual: String = def.decode(buffer).into();
+
     assert_eq!(
         result,
-        field.decode(buffer),
+        actual,
         "Longitude field should be correctly decoded"
-    );
-    assert_eq!(
-        result,
-        field.get().as_ref().expect("no value was set"),
-        "Longitude decoded field value should be correctly set"
     );
 }

--- a/src/wf_field/mod.rs
+++ b/src/wf_field/mod.rs
@@ -17,7 +17,7 @@ pub const FIELD_TESTMESSAGETYPE: &'static str = "PseudoMessageCode";
 
 impl From<&Field> for Vec<u8> {
     fn from(field: &Field) -> Self {
-        field.encode().expect("field has no value")
+        field.encode()
     }
 }
 
@@ -43,12 +43,9 @@ pub fn get_field_value_from_array<T: AsRef<str>>(
     fields: &[Field],
     field_name: T,
 ) -> Option<&String> {
-    let value = fields
+    fields
         .iter()
-        .find(|f| f.definition.name == field_name.as_ref())?
-        .get();
-
-    value.as_ref()
+        .find(|f| f.definition.name == field_name.as_ref()).map(|s| {s.get()})
 }
 
 pub fn get_message_code(fields: &[Field]) -> char {


### PR DESCRIPTION
After splitting `Field` and `FieldDefinition`, it can now be certain that there will be a value in the `Field` struct and the `Option` is obsolete