### PR TITLE
simplifying message segment

### DIFF
--- a/src/wf_convert/mod.rs
+++ b/src/wf_convert/mod.rs
@@ -1,5 +1,4 @@
 use crate::wf_core::basic_message::BasicMessage;
-use crate::wf_core::segment::MessageSegment;
 use crate::wf_field::{generic_header_fields, get_message_body, Field, FieldDefinition};
 
 pub trait FieldValue: AsRef<str> + Into<String> {}
@@ -15,11 +14,7 @@ fn compile<T: FieldValue>(data: &[T]) -> BasicMessage {
 
     let body = set_all(body_field_defs, data.as_ref(), body_start_index);
 
-    BasicMessage::new(
-        code,
-        MessageSegment::from(header),
-        MessageSegment::from(body),
-    )
+    BasicMessage::new(code, header, body)
 }
 
 impl<T: FieldValue> From<&[T]> for BasicMessage {

--- a/src/wf_core/creator.rs
+++ b/src/wf_core/creator.rs
@@ -1,5 +1,4 @@
 use super::basic_message::BasicMessage;
-use super::segment::MessageSegment;
 use crate::wf_buffer::WhiteflagBuffer;
 use crate::wf_convert::FieldValue;
 use crate::wf_field::{generic_header_fields, get_message_body};
@@ -34,11 +33,7 @@ pub fn decode<T: AsRef<str>>(message: T) -> BasicMessage {
     //bit_cursor += header.bit_length();
     //next_field = body.fields.len();
 
-    BasicMessage::new(
-        code,
-        MessageSegment::from(header),
-        MessageSegment::from(body),
-    )
+    BasicMessage::new(code, header.into(), body.into())
 }
 
 /* public final WfMessageCreator decode(final WfBinaryBuffer msgBuffer) throws WfCoreException {

--- a/src/wf_core/segment.rs
+++ b/src/wf_core/segment.rs
@@ -1,15 +1,12 @@
 use crate::{wf_buffer::WhiteflagBuffer, wf_field::Field};
+use std::ops::{Deref, DerefMut};
 
 #[derive(Clone)]
 pub struct MessageSegment {
-    pub fields: Vec<Field>,
+    fields: Vec<Field>,
 }
 
 impl MessageSegment {
-    pub fn from(fields: Vec<Field>) -> MessageSegment {
-        MessageSegment { fields }
-    }
-
     /**
      * Encodes this message segment
      * @return a binary buffer with the binary encoded message segment and its bit length
@@ -37,7 +34,7 @@ impl MessageSegment {
      * @return the bit length of this segment
      */
     pub fn bit_length(&self) -> usize {
-        self.bit_length_of_field(self.fields.len() as isize)
+        self.bit_length_of_field(self.len() as isize)
     }
 
     /**
@@ -55,7 +52,7 @@ impl MessageSegment {
         /* Calculate segment bit length */
         let mut bit_length = 0;
         for index in 0..last_field_index as usize {
-            bit_length += self.fields[index].bit_length();
+            bit_length += self[index].bit_length();
         }
 
         bit_length
@@ -67,7 +64,7 @@ impl MessageSegment {
      * @return the absolute field index or -1 if index out of bounds
      */
     fn get_absolute_index(&self, index: isize) -> isize {
-        let length = self.fields.len() as isize;
+        let length = self.len() as isize;
 
         if index >= 0 && index < length {
             return index;
@@ -78,5 +75,25 @@ impl MessageSegment {
         }
 
         return -1;
+    }
+}
+
+impl Deref for MessageSegment {
+    type Target = Vec<Field>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.fields
+    }
+}
+
+impl DerefMut for MessageSegment {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.fields
+    }
+}
+
+impl From<Vec<Field>> for MessageSegment {
+    fn from(fields: Vec<Field>) -> Self {
+        MessageSegment { fields }
     }
 }


### PR DESCRIPTION
the message segment concept comes from the java codebase and it is likely a construct that can be elimintated within the rust context

for now, these changes reduces the references to the MessageSegment struct, thus making it easier to eventually remove when ready