### PR TITLE
API Simplifications

### DIFF
--- a/src/wf_buffer/mod.rs
+++ b/src/wf_buffer/mod.rs
@@ -49,6 +49,11 @@ impl WhiteflagBuffer {
     }
 
     pub fn extract_message_field(&self, definition: FieldDefinition, start_bit: usize) -> Field {
+        let value = self.extract_message_value(&definition, start_bit);
+        Field::new(definition, value)
+    }
+
+    pub fn extract_message_value(&self, definition: &FieldDefinition, start_bit: usize) -> String {
         let field_bit_length = definition.bit_length();
         let bit_length = if field_bit_length >= 1 {
             field_bit_length

--- a/src/wf_codec/encoding.rs
+++ b/src/wf_codec/encoding.rs
@@ -123,7 +123,7 @@ impl Encoding {
      * @return the number of bits in a compressed encoded field
      * java equivalent: Encoding.bitLength (WfMessageCodec.java)
      */
-    pub fn bit_length(&self, byte_length: usize) -> usize {
+    pub fn convert_to_bit_length(&self, byte_length: usize) -> usize {
         if self.is_fixed_length() {
             return self.bit_length;
         }

--- a/src/wf_field/codec_tests.rs
+++ b/src/wf_field/codec_tests.rs
@@ -31,7 +31,7 @@ fn utf_decoding() {
     let buffer = hex::decode("5746").unwrap();
     let result = "WF";
 
-    let actual: String = def.decode(buffer).into();
+    let actual: String = def.decode(buffer);
 
     assert_eq!(result, actual, "UTF-8 field should be correctly decoded");
 }
@@ -64,7 +64,7 @@ fn bin_decoding_1() {
     let buffer = hex::decode("aa").unwrap();
     let result = "101010";
 
-    let actual: String = def.decode(buffer).into();
+    let actual: String = def.decode(buffer);
 
     assert_eq!(result, actual, "Binary field should be correctly decoded");
 }
@@ -97,7 +97,7 @@ fn bin_decoding_2_a() {
     let buffer = hex::decode("80").unwrap();
     let result = "1";
 
-    let actual: String = def.decode(buffer).into();
+    let actual: String = def.decode(buffer);
 
     assert_eq!(result, actual, "Binary field should be correctly decoded");
 }
@@ -108,7 +108,7 @@ fn bin_decoding_2_b() {
     let buffer = hex::decode("7f").unwrap();
     let result = "0";
 
-    let actual: String = def.decode(buffer).into();
+    let actual: String = def.decode(buffer);
 
     assert_eq!(result, actual, "Binary field should be correctly decoded");
 }
@@ -141,7 +141,7 @@ fn dec_decoding() {
     let buffer = hex::decode("1234").unwrap();
     let result = "123";
 
-    let actual: String = def.decode(buffer).into();
+    let actual: String = def.decode(buffer);
 
     assert_eq!(result, actual, "Decimal field should be correctly decoded");
 }
@@ -174,7 +174,7 @@ fn hex_decoding() {
     let buffer = crate::wf_buffer::decode_hex("0x3f").unwrap();
     let result = "3f";
 
-    let actual: String = def.decode(buffer).into();
+    let actual: String = def.decode(buffer);
 
     assert_eq!(
         result, actual,
@@ -210,7 +210,7 @@ fn datetime_decoding() {
     let buffer = hex::decode("20200701214223").unwrap();
     let result = "2020-07-01T21:42:23Z";
 
-    let actual: String = def.decode(buffer).into();
+    let actual: String = def.decode(buffer);
 
     assert_eq!(result, actual, "DateTime field should be correctly decoded");
 }
@@ -243,7 +243,7 @@ fn duration_decoding() {
     let buffer = hex::decode("241130").unwrap();
     let result = "P24D11H30M";
 
-    let actual: String = def.decode(buffer).into();
+    let actual: String = def.decode(buffer);
 
     assert_eq!(result, actual, "Duration field should be correctly decoded");
 }
@@ -276,7 +276,7 @@ fn latitude_decoding() {
     let buffer = hex::decode("919a1220").unwrap();
     let result = "+23.34244";
 
-    let actual: String = def.decode(buffer).into();
+    let actual: String = def.decode(buffer);
 
     assert_eq!(result, actual, "Latitude field should be correctly decoded");
 }
@@ -309,7 +309,7 @@ fn longitude_decoding_1() {
     let buffer = hex::decode("8b19a12380").unwrap();
     let result = "+163.34247";
 
-    let actual: String = def.decode(buffer).into();
+    let actual: String = def.decode(buffer);
 
     assert_eq!(
         result, actual,
@@ -323,7 +323,7 @@ fn longitude_decoding_2() {
     let buffer = hex::decode("0319a12380").unwrap();
     let result = "-063.34247";
 
-    let actual: String = def.decode(buffer).into();
+    let actual: String = def.decode(buffer);
 
     assert_eq!(
         result, actual,

--- a/src/wf_field/definitions.rs
+++ b/src/wf_field/definitions.rs
@@ -25,13 +25,23 @@ pub enum FieldKind {
     REQUEST,
 }
 
-fn message_code() -> FieldDefinition {
+pub fn message_code() -> FieldDefinition {
     FieldDefinition::new(
         "MessageCode",
         Regex::new("^[A-Z]{1}$").ok(), //"(?=A|K|T|P|E|S|D|I|M|Q|R|F)^[A-Z]{1}$"
         UTF8,
         5,
         6,
+    )
+}
+
+pub fn test_message_code() -> FieldDefinition {
+    FieldDefinition::new(
+        "PseudoMessageCode",
+        Regex::new("^[A-Z]{1}$").ok(),
+        UTF8,
+        71,
+        72,
     )
 }
 
@@ -138,13 +148,7 @@ fn resource_body_fields() -> [FieldDefinition; 2] {
 }
 
 fn test_body_fields() -> [FieldDefinition; 1] {
-    [FieldDefinition::new(
-        "PseudoMessageCode",
-        Regex::new("^[A-Z]{1}$").ok(),
-        UTF8,
-        71,
-        72,
-    )]
+    [test_message_code()]
 }
 
 fn sign_signal_body_fields() -> [FieldDefinition; 9] {

--- a/src/wf_field/field.rs
+++ b/src/wf_field/field.rs
@@ -80,7 +80,7 @@ impl Field {
      * @return the bit length of the compressed encoded field value
      */
     pub fn bit_length(&self) -> usize {
-        return self.definition.encoding.bit_length(self.byte_length());
+        return self.definition.encoding.convert_to_bit_length(self.byte_length());
     }
 
     /**

--- a/src/wf_field/field.rs
+++ b/src/wf_field/field.rs
@@ -80,7 +80,10 @@ impl Field {
      * @return the bit length of the compressed encoded field value
      */
     pub fn bit_length(&self) -> usize {
-        return self.definition.encoding.convert_to_bit_length(self.byte_length());
+        return self
+            .definition
+            .encoding
+            .convert_to_bit_length(self.byte_length());
     }
 
     /**

--- a/src/wf_field/field_definition.rs
+++ b/src/wf_field/field_definition.rs
@@ -90,7 +90,11 @@ impl FieldDefinition {
         }
     }
 
-    pub fn decode(self, data: Vec<u8>) -> Field {
+    pub fn decode(&self, data: Vec<u8>) -> String {
+        self.encoding.decode(data, self.bit_length())
+    }
+
+    pub fn decode_to_field(self, data: Vec<u8>) -> Field {
         let value = self.encoding.decode(data, self.bit_length());
         Field::new(self, value)
     }

--- a/src/wf_field/field_definition.rs
+++ b/src/wf_field/field_definition.rs
@@ -120,6 +120,6 @@ impl FieldDefinition {
      * @return the bit length of the compressed encoded field value
      */
     pub fn bit_length(&self) -> usize {
-        return self.encoding.bit_length(self.byte_length());
+        return self.encoding.convert_to_bit_length(self.byte_length());
     }
 }

--- a/src/wf_field/test.rs
+++ b/src/wf_field/test.rs
@@ -1,6 +1,8 @@
 use crate::wf_codec::encoding::{BIN, DATETIME, DEC, HEX, UTF8};
 use crate::{wf_buffer::WhiteflagBuffer, wf_field::Field, wf_field::FieldDefinition};
 
+use super::definitions;
+
 const FIELDNAME: &str = "TESTFIELD";
 
 #[test]
@@ -30,11 +32,10 @@ fn test_add_field_utf() {
 fn test_extract_field_utf() {
     let buffer: WhiteflagBuffer = vec![0x95, 0x74, 0x78, 0x74].into();
     let def = FieldDefinition::new(FIELDNAME, None, UTF8, 0, -1);
-    let field = buffer.extract_message_field(def, 8);
+    let field = buffer.extract_message_value(&def, 8);
 
     assert_eq!(
-        "txt",
-        field.get(),
+        "txt", field,
         "Extracted message field (UTF) should contain the correct value"
     );
 }
@@ -110,11 +111,10 @@ fn test_extract_field_dec() {
     let buffer: WhiteflagBuffer = vec![0x95, 0x91, 0xFF, 0xE7].into();
     let def = FieldDefinition::new(FIELDNAME, None, DEC, 0, 2);
 
-    let field = buffer.extract_message_field(def, 10);
+    let field = buffer.extract_message_value(&def, 10);
 
     assert_eq!(
-        "47",
-        field.get(),
+        "47", field,
         "Extracted message field (dec) should contain the correct value"
     );
 }
@@ -147,11 +147,10 @@ fn test_extract_field_hex() {
     let buffer: WhiteflagBuffer = vec![0x95, 0xDD, 0xFF, 0xE7].into();
 
     let def: FieldDefinition = FieldDefinition::new(FIELDNAME, None, HEX, 0, 2);
-    let field = buffer.extract_message_field(def, 9);
+    let field = buffer.extract_message_value(&def, 9);
 
     assert_eq!(
-        "bb",
-        field.get(),
+        "bb", field,
         "Extracted message field (dec) should contain the correct value"
     );
 }
@@ -177,4 +176,14 @@ fn test_add_field_date_time() {
         buffer.as_hex(),
         "Message field (hex) should be correctly encoded and added"
     );
+}
+
+#[test]
+fn test_extract_message_code() {
+    let def = definitions::message_code();
+    let buffer = WhiteflagBuffer::decode_from_hexadecimal("5746313020800000000000000000000000000000000000000000000000000000000000000000b43a3a38399d1797b7b933b0b734b9b0ba34b7b71734b73a17bbb434ba32b33630b380").unwrap();
+
+    let field = buffer.extract_message_value(&def, 33);
+
+    assert_eq!("A", field, "extracted message code should be A");
 }


### PR DESCRIPTION
these changes are motivated by the codec edge case logic I am actively working on completing and will facilitate that port

- `WhiteflagBuffer`: added `extract_message_value` which does not require ownership transfer of `FieldDefinition`
- `FieldDefinition`: `decode` now returns a `String` and there is a new method `decode_to_field` which is functionally the same but will convert the definition into a `Field`
- `Encoding`: changed name from `bit_length` to `convert_to_bit_length` as it more clearly expresses the functions intent