### PR TITLE
Docs & Clippy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,5 @@ brew install openssl cmake llvm
 
 ## Windows
 
-```
 - [openssl on windows](https://github.com/fennelLabs/fennel-lib/issues/1)
 - [llvm on windows](https://community.chocolatey.org/packages/llvm)
-```

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,4 @@
 use thiserror::Error;
-pub type WhiteflagResult<T> = Result<T, WhiteflagError>;
 
 #[derive(Error, Debug)]
 pub enum WhiteflagError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,26 @@ mod error;
 mod wf_core;
 mod wf_json;
 
+/// encode whiteflag json message into a hexadecimal string
+///
+/// # Example
+/// ```
+/// let json = serde_json::json!({
+///    "prefix": "WF",
+///    "version": "1",
+///    "encryptionIndicator": "0",
+///    "duressIndicator": "0",
+///    "messageCode": 'A',
+///    "referenceIndicator": "0",
+///    "referencedMessage": "0000000000000000000000000000000000000000000000000000000000000000",
+///    "verificationMethod": "1",
+///    "verificationData": "https://organisation.int/whiteflag"
+/// }).to_string();
+/// let wf_message = fennel_whiteflag::encode_from_json(json).unwrap();
+/// let hex = "5746313020800000000000000000000000000000000000000000000000000000000000000000b43a3a38399d1797b7b933b0b734b9b0ba34b7b71734b73a17bbb434ba32b33630b380";
+///
+/// assert_eq!(hex, wf_message);
+/// ```
 pub fn encode_from_json<T: AsRef<str>>(json: T) -> Result<String, WhiteflagError> {
     let message: wf_json::WhiteflagFieldValues =
         serde_json::from_str(json.as_ref()).map_err(|e| WhiteflagError::Serde(e))?;
@@ -12,6 +32,27 @@ pub fn encode_from_json<T: AsRef<str>>(json: T) -> Result<String, WhiteflagError
     Ok(wf_core::encode(&message.fields))
 }
 
+/// decode hexadecimal encoded whiteflag message into a json message
+///
+/// # Example
+/// ```
+/// let hex = "5746313020800000000000000000000000000000000000000000000000000000000000000000b43a3a38399d1797b7b933b0b734b9b0ba34b7b71734b73a17bbb434ba32b33630b380";
+/// let wf_message = fennel_whiteflag::decode_from_hex(hex).unwrap();
+///
+/// let json = serde_json::json!({
+///    "prefix": "WF",
+///    "version": "1",
+///    "encryptionIndicator": "0",
+///    "duressIndicator": "0",
+///    "messageCode": 'A',
+///    "referenceIndicator": "0",
+///    "referencedMessage": "0000000000000000000000000000000000000000000000000000000000000000",
+///    "verificationMethod": "1",
+///    "verificationData": "https://organisation.int/whiteflag"
+/// });
+///
+/// assert_eq!(json.as_object().unwrap(), &serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&wf_message).unwrap());
+/// ```
 pub fn decode_from_hex<T: AsRef<str>>(hex: T) -> Result<String, WhiteflagError> {
     let message = wf_core::decode(hex);
     let json = serde_json::to_string(&message).map_err(|e| WhiteflagError::Serde(e))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ mod wf_json;
 /// ```
 pub fn encode_from_json<T: AsRef<str>>(json: T) -> Result<String, WhiteflagError> {
     let message: wf_json::WhiteflagFieldValues =
-        serde_json::from_str(json.as_ref()).map_err(|e| WhiteflagError::Serde(e))?;
+        serde_json::from_str(json.as_ref()).map_err(WhiteflagError::Serde)?;
 
     Ok(wf_core::encode(&message.fields))
 }
@@ -55,7 +55,7 @@ pub fn encode_from_json<T: AsRef<str>>(json: T) -> Result<String, WhiteflagError
 /// ```
 pub fn decode_from_hex<T: AsRef<str>>(hex: T) -> Result<String, WhiteflagError> {
     let message = wf_core::decode(hex);
-    let json = serde_json::to_string(&message).map_err(|e| WhiteflagError::Serde(e))?;
+    let json = serde_json::to_string(&message).map_err(WhiteflagError::Serde)?;
 
     Ok(json)
 }

--- a/src/wf_core/crypted_buffer.rs
+++ b/src/wf_core/crypted_buffer.rs
@@ -2,6 +2,11 @@ use aes_tools::FennelCipher;
 use wf_buffer::WhiteflagBuffer;
 use wf_field::definitions::WhiteflagFields;
 
+/// everything is encrypted in a whiteflag buffer except for the first few header fields
+///
+/// Prefix, Version, and EncryptionIndicator do not get encrypted
+/// Therefore, when encrypting, the buffer is split and the second half gets encrypted
+/// Likewise, when decrypting, the buffer is split and the second half gets decrypted
 pub struct CryptedBuffer {
     unencrypted_first_half: WhiteflagBuffer,
     encrypted_second_half: WhiteflagBuffer,
@@ -13,6 +18,7 @@ pub enum CryptMode {
 }
 
 impl CryptedBuffer {
+    /// creates a new [`CryptedBuffer`] by splitting the given buffer at the EncryptionHeader bit index
     pub fn new(buffer: WhiteflagBuffer) -> Self {
         Self::new_split_at(
             buffer,
@@ -22,6 +28,7 @@ impl CryptedBuffer {
         )
     }
 
+    /// splits the buffer at the chosen index
     fn new_split_at(buffer: WhiteflagBuffer, split_at: usize) -> Self {
         let unencrypted_first_half = buffer.extract_bits(0, split_at);
         let encrypted_second_half = buffer.extract_bits_from(split_at);
@@ -32,6 +39,7 @@ impl CryptedBuffer {
         }
     }
 
+    /// creates an encrypted [`WhiteflagBuffer`] or decrypted [`WhiteflagBuffer`] depending on [`CryptMode`]
     pub fn crypt<T: FennelCipher>(self, cipher: &T, mode: CryptMode) -> WhiteflagBuffer {
         let mut buffer = WhiteflagBuffer::default();
 

--- a/src/wf_core/message.rs
+++ b/src/wf_core/message.rs
@@ -30,7 +30,7 @@ impl MessageSegment {
     pub fn serialize(&self) -> String {
         let mut serial: String = String::new();
         for f in self.iter() {
-            let value: &str = &f.get();
+            let value: &str = f.get();
             serial.push_str(value);
         }
 

--- a/src/wf_core/wf_message_builder.rs
+++ b/src/wf_core/wf_message_builder.rs
@@ -34,12 +34,11 @@ impl<T: FieldValue> FieldDefinitionParser for FieldValuesParser<'_, T> {
     fn parse(&mut self, definition: &FieldDefinition) -> String {
         let value = self.data[self.index].as_ref();
 
-        match definition.validate(value) {
-            Err(e) => panic!(
+        if let Err(e) = definition.validate(value) {
+            panic!(
                 "{} error while converting array of strings into fields\n{0:?}",
                 e
-            ),
-            _ => (),
+            )
         };
 
         self.index += 1;
@@ -76,7 +75,7 @@ pub fn builder_from_field_values<T: FieldValue>(data: &[T]) -> Parser {
     Parser::parse(parser)
 }
 
-pub fn builder_from_serialized<'a>(message: &'a str) -> Parser {
+pub fn builder_from_serialized(message: &str) -> Parser {
     let parser = SerializedMessageParser {
         message,
         last_byte: 0,

--- a/src/wf_json/deserialize.rs
+++ b/src/wf_json/deserialize.rs
@@ -31,7 +31,7 @@ impl<'de> de::Visitor<'de> for FieldValuesVisitor {
         let mut fields: HashMap<usize, String> = HashMap::new();
 
         while let Some((key, value)) = map.next_entry::<String, String>()? {
-            let index = name_map(&key).map_err(|e| serde::de::Error::custom(e))?;
+            let index = name_map(&key).map_err(serde::de::Error::custom)?;
             fields.insert(index, value);
         }
 

--- a/src/wf_json/mod.rs
+++ b/src/wf_json/mod.rs
@@ -12,7 +12,7 @@ impl Message {
     #[allow(dead_code)]
     pub fn deserialize_from_json<T: AsRef<str>>(json: T) -> Result<Self, WhiteflagError> {
         let message: WhiteflagFieldValues =
-            serde_json::from_str(json.as_ref()).map_err(|e| WhiteflagError::Serde(e))?;
+            serde_json::from_str(json.as_ref()).map_err(WhiteflagError::Serde)?;
         Ok(Message::compile(message.fields.as_ref()))
     }
 }

--- a/src/wf_json/mod.rs
+++ b/src/wf_json/mod.rs
@@ -9,6 +9,7 @@ pub use deserialize::WhiteflagFieldValues;
 use crate::{error::WhiteflagError, wf_core::message::Message};
 
 impl Message {
+    #[allow(dead_code)]
     pub fn deserialize_from_json<T: AsRef<str>>(json: T) -> Result<Self, WhiteflagError> {
         let message: WhiteflagFieldValues =
             serde_json::from_str(json.as_ref()).map_err(|e| WhiteflagError::Serde(e))?;

--- a/src/wf_json/serialize.rs
+++ b/src/wf_json/serialize.rs
@@ -12,7 +12,7 @@ impl Serialize for Message {
         let mut state = serializer.serialize_struct("BasicMessage", length)?;
 
         for f in fields {
-            let json_name = name_map(f.get_name()).map_err(|e| serde::ser::Error::custom(e))?;
+            let json_name = name_map(f.get_name()).map_err(serde::ser::Error::custom)?;
             state.serialize_field(json_name, f.get())?;
         }
 

--- a/src/wf_json/test.rs
+++ b/src/wf_json/test.rs
@@ -1,6 +1,4 @@
-use crate::{
-    decode_from_hex, wf_core::message::Message, wf_json::deserialize::WhiteflagFieldValues,
-};
+use crate::{decode_from_hex, wf_json::deserialize::WhiteflagFieldValues};
 use serde_json::json;
 
 #[test]

--- a/watch.sh
+++ b/watch.sh
@@ -1,2 +1,4 @@
 # https://lib.rs/crates/cargo-watch
+# cargo install cargo-expand
+
 cargo watch -q -c -x 'expand wf_field::definitions'

--- a/wf_account/src/whiteflag_account.rs
+++ b/wf_account/src/whiteflag_account.rs
@@ -20,7 +20,7 @@ pub struct WhiteflagAccount {
 impl WfAccount for WhiteflagAccount {
     fn new(owned: bool) -> Self {
         WhiteflagAccount {
-            owned: owned,
+            owned,
             address: None,
             auth_url: None,
             auth_token: None,
@@ -82,7 +82,7 @@ impl WfAccount for WhiteflagAccount {
             Err(WhiteflagAccountError::CantSetECDHPair)
         } else {
             self.ecdh_keypair = Some(ecdh_keypair.clone());
-            self.ecdh_public_key = Some(ecdh_keypair.as_ref().clone());
+            self.ecdh_public_key = Some(*ecdh_keypair.as_ref());
             Ok(())
         }
     }

--- a/wf_auth/src/lib.rs
+++ b/wf_auth/src/lib.rs
@@ -36,18 +36,6 @@ struct WhiteflagAuthMethod {
 }
 
 impl WhiteflagAuthMethod {
-    pub fn new(
-        value: AuthenticationMethod,
-        length: usize,
-        hkdf_salt: Vec<u8>,
-    ) -> WhiteflagAuthMethod {
-        WhiteflagAuthMethod {
-            value,
-            length,
-            hkdf_salt,
-        }
-    }
-
     pub fn get_preshared_token() -> Self {
         WhiteflagAuthMethod {
             value: AuthenticationMethod::PresharedToken,

--- a/wf_buffer/src/common.rs
+++ b/wf_buffer/src/common.rs
@@ -17,7 +17,7 @@ impl WhiteflagBuffer {
     }
 
     pub fn append(&mut self, mut buffer: WhiteflagBuffer, bits: Option<usize>) {
-        let bit_length_to_extract = bits.unwrap_or_else(|| buffer.bit_length);
+        let bit_length_to_extract = bits.unwrap_or(buffer.bit_length);
         let (buffer, length) = append_bits(
             &self.data,
             self.bit_length,
@@ -35,7 +35,7 @@ impl WhiteflagBuffer {
 
     /// Returns the Whiteflag encoded message as a byte array
     /// @return a byte array with an encoded message
-    pub fn to_byte_array<'a>(&'a mut self) -> &'a [u8] {
+    pub fn to_byte_array(&mut self) -> &[u8] {
         crop_bits(self.data.as_mut(), self.bit_length);
         &self.data
     }

--- a/wf_buffer/src/conversions.rs
+++ b/wf_buffer/src/conversions.rs
@@ -67,15 +67,6 @@ impl From<Vec<u8>> for WhiteflagBuffer {
     }
 }
 
-impl Default for WhiteflagBuffer {
-    fn default() -> Self {
-        Self {
-            data: Default::default(),
-            bit_length: Default::default(),
-        }
-    }
-}
-
 impl From<WhiteflagBuffer> for Vec<u8> {
     fn from(buffer: WhiteflagBuffer) -> Self {
         buffer.data

--- a/wf_buffer/src/decode.rs
+++ b/wf_buffer/src/decode.rs
@@ -9,14 +9,14 @@ impl WhiteflagBuffer {
     /// * `field_defs` - field definitions required to decode the buffer
     /// * `start_bit` - the bit position where this segment starts in the encoded buffer
     pub fn decode(&self, field_defs: &[FieldDefinition], start_bit: usize) -> (usize, Vec<Field>) {
-        if field_defs.len() < 1 {
+        if field_defs.is_empty() {
             panic!("field definition vector should not be empty")
         }
 
         let mut bit_cursor = start_bit;
 
         let fields = field_defs
-            .into_iter()
+            .iter()
             .map(|f| {
                 let field = self.extract_message_field(f, bit_cursor);
                 bit_cursor += field.bit_length();

--- a/wf_buffer/src/encode.rs
+++ b/wf_buffer/src/encode.rs
@@ -8,7 +8,7 @@ impl WhiteflagBuffer {
     ///
     /// * `fields` - array of fields to append and encode into the buffer
     pub fn encode(&mut self, fields: &[Field]) {
-        fields.into_iter().for_each(|f| self.append_field(f));
+        fields.iter().for_each(|f| self.append_field(f));
     }
 
     pub fn append_field(&mut self, field: &Field) {

--- a/wf_buffer/src/lib.rs
+++ b/wf_buffer/src/lib.rs
@@ -11,6 +11,7 @@ mod conversions;
 mod decode;
 mod encode;
 
+#[derive(Default)]
 pub struct WhiteflagBuffer {
     data: Vec<u8>,
     bit_length: usize,
@@ -29,6 +30,6 @@ pub trait BufferReader {
 impl BufferReader for FieldDefinition {
     /// used in the decoding process
     fn read(&self, buffer: &WhiteflagBuffer) -> String {
-        buffer.extract_message_value(&self, self.positions.bit_start)
+        buffer.extract_message_value(self, self.positions.bit_start)
     }
 }

--- a/wf_codec/src/encoding.rs
+++ b/wf_codec/src/encoding.rs
@@ -79,37 +79,12 @@ impl From<ConfiguredByteLength> for ByteLength {
     }
 }
 
-/* impl EncodingKind {
-    pub fn get_charset(&self) -> &'static str {
-        match self {
-            EncodingKind::BIN => "[01]",
-            _ => "",
-        }
-    }
-} */
-
 impl Encoding {
-    fn new(
-        charset: &'static str,
-        bit_length: usize,
-        byte_length: ConfiguredByteLength,
-        kind: EncodingKind,
-    ) -> Encoding {
-        Encoding {
-            charset,
-            bit_length,
-            byte_length,
-            kind,
-        }
-    }
-
-    /**
-     * Encodes a Whiteflag message field to compressed binary representation
-     * @since 1.1
-     * @param field the message field to be encoded
-     * @return a binary buffer with the encoded field
-     * java equivalent: WfMessageCodec.encodeField
-     */
+    /// Encodes a Whiteflag message field to compressed binary representation
+    /// @since 1.1
+    /// @param field the message field to be encoded
+    /// @return a binary buffer with the encoded field
+    /// java equivalent: WfMessageCodec.encodeField
     pub fn encode<T: AsRef<str> + std::fmt::Display>(&self, value: T) -> Vec<u8> {
         match &self.kind {
             EncodingKind::UTF8 => value.as_ref().as_bytes().to_vec(),
@@ -122,14 +97,12 @@ impl Encoding {
         }
     }
 
-    /**
-     * Sets the field value from a binary buffer
-     * @since 1.1
-     * @param field the field for which to decode the binary value
-     * @param buffer a binary buffer with the compressed binary encoded field data
-     * @return the uncompressed value of the field
-     * java equivalent: WfMessageCodec.decodeField
-     */
+    /// Sets the field value from a binary buffer
+    /// @since 1.1
+    /// @param field the field for which to decode the binary value
+    /// @param buffer a binary buffer with the compressed binary encoded field data
+    /// @return the uncompressed value of the field
+    /// java equivalent: WfMessageCodec.decodeField
     pub fn decode(&self, buffer: &[u8], bit_length: usize) -> CodecResult<String> {
         let mut s = String::new();
 
@@ -181,12 +154,10 @@ impl Encoding {
         self.byte_length.as_opt() != None
     }
 
-    /**
-     * Returns the bit length of a field for a given encoding and unencoded field byte length
-     * @param byteLength the number of bytes in the unencoded field
-     * @return the number of bits in a compressed encoded field
-     * java equivalent: Encoding.bitLength (WfMessageCodec.java)
-     */
+    /// Returns the bit length of a field for a given encoding and unencoded field byte length
+    /// @param byteLength the number of bytes in the unencoded field
+    /// @return the number of bits in a compressed encoded field
+    /// java equivalent: Encoding.bitLength (WfMessageCodec.java)
     pub fn convert_to_bit_length(&self, byte_length: usize) -> usize {
         if self.is_fixed_length() {
             return self.bit_length;
@@ -195,10 +166,7 @@ impl Encoding {
     }
 }
 
-/**
- * The equivalent of following constants can be found as an enum called "Encoding" in WfMessageCodec.java
- */
-
+/// The equivalent of following constants can be found as an enum called "Encoding" in WfMessageCodec.java
 macro_rules! encoding {
     (
         $( $name:ident, $charset:expr, $bit_length:expr, $byte_length:expr );*

--- a/wf_codec/src/encoding.rs
+++ b/wf_codec/src/encoding.rs
@@ -151,7 +151,7 @@ impl Encoding {
     }
 
     pub fn is_fixed_length(&self) -> bool {
-        self.byte_length.as_opt() != None
+        self.byte_length.as_opt().is_some()
     }
 
     /// Returns the bit length of a field for a given encoding and unencoded field byte length

--- a/wf_codec/src/error.rs
+++ b/wf_codec/src/error.rs
@@ -1,6 +1,6 @@
 use std::str::Utf8Error;
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum CodecError {
     #[error("the buffer is not UTF8 formatted")]
     UTF8(#[from] Utf8Error),

--- a/wf_codec/src/latlong.rs
+++ b/wf_codec/src/latlong.rs
@@ -4,8 +4,8 @@ use wf_common::{
     constants::QUADBIT,
 };
 
-const PLUS: &'static str = "+";
-const MINUS: &'static str = "-";
+const PLUS: &str = "+";
+const MINUS: &str = "-";
 
 /**
  * Encodes a datum string into binary buffer

--- a/wf_common/src/common.rs
+++ b/wf_common/src/common.rs
@@ -1,9 +1,7 @@
 use super::constants::*;
 
-/**
- * removes characters from string that are invalid in hexadecimal format
- * java equivalent: N/A
- */
+/// removes characters from string that are invalid in hexadecimal format
+/// java equivalent: N/A
 pub fn remove_all_invalid_hex_characters<T: AsRef<str>>(data: T) -> String {
     let re = regex::Regex::new("[-+:.A-Z]").unwrap();
     re.replace_all(data.as_ref(), "").to_string()
@@ -21,19 +19,15 @@ pub fn remove_hexadecimal_prefix_mut(mut data: &str) {
     data = remove_hexadecimal_prefix(data);
 }
 
-/**
- * Calculates the number of bytes required to hold the given number of bits
- * java equivalent: WfBinaryBuffer.byteLength
- */
+/// Calculates the number of bytes required to hold the given number of bits
+/// java equivalent: WfBinaryBuffer.byteLength
 pub fn byte_length(bit_length: usize) -> usize {
     let i_byte = BYTE;
     (bit_length / i_byte) + (if (bit_length % i_byte) > 0 { 1 } else { 0 })
 }
 
-/**
- * Shortens the byte array to fit the length of the used bits
- * java equivalent: WfBinaryBuffer.cropBits
- */
+/// Shortens the byte array to fit the length of the used bits
+/// java equivalent: WfBinaryBuffer.cropBits
 pub fn crop_bits(buffer: &mut Vec<u8>, bit_length: usize) {
     if bit_length == 0 {
         return;
@@ -58,10 +52,8 @@ pub fn crop_bits(buffer: &mut Vec<u8>, bit_length: usize) {
     }
 }
 
-/**
- * Shifts bits in a byte array to the right modulo 8
- * java equivalent: WfBinaryBuffer.shiftRight
- */
+/// Shifts bits in a byte array to the right modulo 8
+/// java equivalent: WfBinaryBuffer.shiftRight
 pub fn shift_right(buffer: &[u8], shift: isize) -> Vec<u8> {
     if shift < 0 {
         return shift_left(buffer, -shift);
@@ -86,10 +78,8 @@ pub fn shift_right(buffer: &[u8], shift: isize) -> Vec<u8> {
     new_buffer
 }
 
-/**
- * Shifts bits in a byte array to the left modulo 8
- * java equivalent: WfBinaryBuffer.shiftLeft
- */
+/// Shifts bits in a byte array to the left modulo 8
+/// java equivalent: WfBinaryBuffer.shiftLeft
 pub fn shift_left(buffer: &[u8], shift: isize) -> Vec<u8> {
     if shift < 0 {
         return shift_right(buffer, -shift);
@@ -115,13 +105,11 @@ pub fn shift_left(buffer: &[u8], shift: isize) -> Vec<u8> {
     new_buffer
 }
 
-/**
- * Returns a byte array with a subset of the bits in the buffer
- * @param startBit the first bit of the subset to extract
- * @param bitLength the length of the subset, i.e. the number of bits to extract
- * @return a byte array with the extracted bits
- * java equivalent: WfBinaryBuffer.extractBits
- */
+/// Returns a byte array with a subset of the bits in the buffer
+/// @param startBit the first bit of the subset to extract
+/// @param bitLength the length of the subset, i.e. the number of bits to extract
+/// @return a byte array with the extracted bits
+/// java equivalent: WfBinaryBuffer.extractBits
 pub fn extract_bits(
     buffer: &[u8],
     buffer_bit_length: usize,
@@ -165,14 +153,11 @@ pub fn extract_bits(
     new_byte_array
 }
 
-/**
- * Appends the specified number of bits from a bytes array to the binary buffer
- * @param byteArray the byte array with the bits to be appended
- * @param nBits the number of bits to be appended from the byte array
- * @return this binary buffer
- * @throws IllegalStateException if the buffer is marked complete and cannot be altered
- * java equivalent: WfBinaryBuffer.appendBits
- */
+/// Appends the specified number of bits from a bytes array to the binary buffer
+/// @param byteArray the byte array with the bits to be appended
+/// @param nBits the number of bits to be appended from the byte array
+/// @return this binary buffer
+/// java equivalent: WfBinaryBuffer.appendBits
 pub fn append_bits(
     buffer_1: &[u8],
     len_1: usize,
@@ -191,15 +176,13 @@ pub fn append_bits(
     (new_buffer, len_1 + len_2)
 }
 
-/**
- * Concatinates two bitsets
- * @param byte_array_1 byte array containing the first bitset
- * @param n_bits_1 number of bits in the first bitset, i.e. which bits to take from the first byte array
- * @param byte_array_2 byte array containing the second bitset
- * @param n_bits_2 number of bits in the second bitset, i.e. which bits to take from the second byte array
- * @return a new byte array with the concatinated bits
- * java equivalent: WfBinaryBuffer.concatinateBits
- */
+/// Concatinates two bitsets
+/// @param byte_array_1 byte array containing the first bitset
+/// @param n_bits_1 number of bits in the first bitset, i.e. which bits to take from the first byte array
+/// @param byte_array_2 byte array containing the second bitset
+/// @param n_bits_2 number of bits in the second bitset, i.e. which bits to take from the second byte array
+/// @return a new byte array with the concatinated bits
+/// java equivalent: WfBinaryBuffer.concatinateBits
 pub fn concatinate_bits(
     byte_array_1: &[u8],
     mut n_bits_1: usize,

--- a/wf_common/src/common.rs
+++ b/wf_common/src/common.rs
@@ -8,8 +8,8 @@ pub fn remove_all_invalid_hex_characters<T: AsRef<str>>(data: T) -> String {
 }
 
 pub fn remove_hexadecimal_prefix(data: &str) -> &str {
-    if data.starts_with("0x") {
-        return &data[2..];
+    if let Some(x) = data.strip_prefix("0x") {
+        return x;
     }
 
     data

--- a/wf_common/src/common.rs
+++ b/wf_common/src/common.rs
@@ -39,7 +39,7 @@ pub fn crop_bits(buffer: &mut Vec<u8>, bit_length: usize) {
 
     /* Clear unused bits in last byte */
     let clear_bits = BYTE - (bit_length % BYTE);
-    if !(clear_bits < BYTE) {
+    if clear_bits >= BYTE {
         return;
     }
 
@@ -167,7 +167,7 @@ pub fn append_bits(
     }
 
     /* Add bits to the end of the buffer */
-    let new_buffer = concatinate_bits(&buffer_1, len_1, &buffer_2, len_2);
+    let new_buffer = concatinate_bits(buffer_1, len_1, buffer_2, len_2);
 
     (new_buffer, len_1 + len_2)
 }
@@ -202,7 +202,7 @@ pub fn concatinate_bits(
     let byte_length = byte_length(bit_length);
 
     /* Prepare byte arrays */
-    let byte_array_2_shift = shift_right(&byte_array_2, shift as isize);
+    let byte_array_2_shift = shift_right(byte_array_2, shift as isize);
     let mut new_byte_array = vec![0; byte_length as usize];
 
     /* Concatination */

--- a/wf_common/src/common.rs
+++ b/wf_common/src/common.rs
@@ -15,10 +15,6 @@ pub fn remove_hexadecimal_prefix(data: &str) -> &str {
     data
 }
 
-pub fn remove_hexadecimal_prefix_mut(mut data: &str) {
-    data = remove_hexadecimal_prefix(data);
-}
-
 /// Calculates the number of bytes required to hold the given number of bits
 /// java equivalent: WfBinaryBuffer.byteLength
 pub fn byte_length(bit_length: usize) -> usize {

--- a/wf_common/src/test.rs
+++ b/wf_common/src/test.rs
@@ -1,8 +1,4 @@
-use super::{
-    common::{concatinate_bits, extract_bits},
-    constants::BYTE,
-    *,
-};
+use super::{common::extract_bits, constants::BYTE, *};
 
 fn assert_array_eq<T: PartialEq + std::fmt::Debug>(l: Vec<T>, r: Vec<T>) {
     let success = l.iter().eq(r.iter());

--- a/wf_crypto/src/cipher_tests.rs
+++ b/wf_crypto/src/cipher_tests.rs
@@ -1,7 +1,7 @@
 use crate::{ecdh_keypair::WhiteflagECDHKeyPair, wf_encryption_key::WhiteflagEncryptionKey};
 use aes_tools::FennelCipher;
 
-/// Tests Whiteflag encryption and decryption with pre-shared key and known test vector 
+/// Tests Whiteflag encryption and decryption with pre-shared key and known test vector
 #[test]
 fn test_cipher_1() {
     let plaintext = "23000000000088888889111111119999999a22222222aaaaaaab33333333bbbbbbbb0983098309830983118b118b118b118b1993199319931993219b219b219b219b29a329a329a329a331ab31ab31ab31a9b1b9b1b9b1b9b1b9c1c9c1c9c1c9c1c8";

--- a/wf_crypto/src/cipher_tests.rs
+++ b/wf_crypto/src/cipher_tests.rs
@@ -1,13 +1,7 @@
 use crate::{ecdh_keypair::WhiteflagECDHKeyPair, wf_encryption_key::WhiteflagEncryptionKey};
 use aes_tools::FennelCipher;
 
-/**
- * Whiteflag cipher test class
- */
-
-/**
- * Tests Whiteflag encryption and decryption with pre-shared key and known test vector
- */
+/// Tests Whiteflag encryption and decryption with pre-shared key and known test vector 
 #[test]
 fn test_cipher_1() {
     let plaintext = "23000000000088888889111111119999999a22222222aaaaaaab33333333bbbbbbbb0983098309830983118b118b118b118b1993199319931993219b219b219b219b29a329a329a329a331ab31ab31ab31a9b1b9b1b9b1b9b1b9c1c9c1c9c1c9c1c8";
@@ -24,9 +18,7 @@ fn test_cipher_1() {
     );
 }
 
-/**
- * Tests full Whiteflag encryption scheme and decryption with negotiated key
- */
+/// Tests full Whiteflag encryption scheme and decryption with negotiated key
 #[test]
 fn test_cipher_2() {
     let plaintext1 = "aa1bb2cc3dd4ee5ff6007008009000";

--- a/wf_crypto/src/crypto_util.rs
+++ b/wf_crypto/src/crypto_util.rs
@@ -65,7 +65,7 @@ where
         let mut okm: Vec<u8> = vec![0; key_length];
         self.hk
             .expand(info, &mut okm)
-            .map_err(|e| CryptoError::HkdfOutput(e))?;
+            .map_err(CryptoError::HkdfOutput)?;
         Ok(okm)
     }
 }
@@ -78,7 +78,7 @@ where
     type Error = CryptoError;
 
     fn try_from(prk: &[u8]) -> Result<Self, Self::Error> {
-        let hk = hkdf::Hkdf::<H, I>::from_prk(prk).map_err(|e| CryptoError::HkdfInput(e))?;
+        let hk = hkdf::Hkdf::<H, I>::from_prk(prk).map_err(CryptoError::HkdfInput)?;
         Ok(WhiteflagHkdf {
             hk,
             prk: prk.to_vec(),

--- a/wf_crypto/src/ecdh_keypair.rs
+++ b/wf_crypto/src/ecdh_keypair.rs
@@ -26,8 +26,7 @@ impl WhiteflagECDHKeyPair {
     /// Creates a new random ECDH key with the curve specified for Whiteflag key negotiation
     pub fn new() -> Self {
         let secret: StaticSecret = get_session_secret();
-        let pair = Self::from_secret(secret);
-        pair
+        Self::from_secret(secret)
     }
 
     /// Creates an ECDH key pair from an existing private key with the curve specified for Whiteflag key negotiation
@@ -46,8 +45,7 @@ impl WhiteflagECDHKeyPair {
 
     /// Calculates the negotiated shared key with an originator
     pub fn negotiate_as_shared_secret(&self, other: &PublicKey) -> SharedSecret {
-        let secret = get_shared_secret(self.session_secret.clone(), other);
-        secret
+        get_shared_secret(self.session_secret.clone(), other)
     }
 
     pub fn create_aes_cipher(&self, public_key: &PublicKey) -> AESCipher {

--- a/wf_crypto/src/lib.rs
+++ b/wf_crypto/src/lib.rs
@@ -7,8 +7,10 @@ mod crypto_util_tests;
 #[cfg(test)]
 mod cipher_tests;
 
+#[allow(dead_code)]
 mod crypto_util;
 pub mod ecdh_keypair;
+#[allow(dead_code)]
 pub mod encryption_method;
 mod error;
 pub mod wf_encryption_key;

--- a/wf_crypto/src/wf_encryption_key.rs
+++ b/wf_crypto/src/wf_encryption_key.rs
@@ -6,7 +6,7 @@ use x25519_dalek::PublicKey;
 /// This class represents a Whiteflag encryption key. Instances of this
 /// class represent the raw key, either pre-shared or negotiated, from which
 /// the actual key material for encryption methods 1 and 2 is created.
-/// 
+///
 /// Whiteflag Specification 5.2.3 Key and Token Derivation
 /// Whiteflag Specification 5.2.4 Message Encryption
 #[derive(Clone)]

--- a/wf_crypto/src/wf_encryption_key.rs
+++ b/wf_crypto/src/wf_encryption_key.rs
@@ -3,25 +3,22 @@ use super::encryption_method::WhiteflagEncryptionMethod;
 use aes_tools::{AESCipher, AES256CTR};
 use x25519_dalek::PublicKey;
 
-///This class represents a Whiteflag encryption key. Instances of this
-///class represent the raw key, either pre-shared or negotiated, from which
-///the actual key material for encryption methods 1 and 2 is created.
-///
-///Whiteflag Specification 5.2.3 Key and Token Derivation
-///Whiteflag Specification 5.2.4 Message Encryption
+/// This class represents a Whiteflag encryption key. Instances of this
+/// class represent the raw key, either pre-shared or negotiated, from which
+/// the actual key material for encryption methods 1 and 2 is created.
+/// 
+/// Whiteflag Specification 5.2.3 Key and Token Derivation
+/// Whiteflag Specification 5.2.4 Message Encryption
 #[derive(Clone)]
 pub struct WhiteflagEncryptionKey {
-    /* The encryption method and keys */
-    /**
-    ///The encryption method for which this key is valid
-     */
+    /// The encryption method for which this key is valid
     method: WhiteflagEncryptionMethod,
-    /* The raw key materials */
+    /// The raw key materials
     secret_key: Vec<u8>,
 }
 
 impl WhiteflagEncryptionKey {
-    ///Constructs a new Whiteflag encryption key through ECDH key negotiation
+    /// Constructs a new Whiteflag encryption key through ECDH key negotiation
     pub fn from_ecdh_key(public_key: &PublicKey, ecdh_key_pair: &WhiteflagECDHKeyPair) -> Self {
         WhiteflagEncryptionKey {
             secret_key: ecdh_key_pair.negotiate(public_key),

--- a/wf_field/src/byte_configuration.rs
+++ b/wf_field/src/byte_configuration.rs
@@ -51,7 +51,7 @@ impl ByteConfiguration {
     }
 }
 
-struct ByteCursorTracker {
+/* struct ByteCursorTracker {
     cursor: usize,
 }
 
@@ -71,4 +71,4 @@ impl ByteCursorTracker {
 
         Ok(())
     }
-}
+} */

--- a/wf_field/src/codec_tests.rs
+++ b/wf_field/src/codec_tests.rs
@@ -1,4 +1,4 @@
-use super::{Field, FieldDefinition};
+use super::FieldDefinition;
 use wf_codec::encoding::*;
 
 const FIELDNAME: &str = "TESTFIELD";

--- a/wf_field/src/definitions.rs
+++ b/wf_field/src/definitions.rs
@@ -9,7 +9,6 @@ macro_rules! module {
         $name:ident, $($code:item)*
     ) => {
         pub mod $name {
-            use super::*;
             $( $code )*
         }
     };

--- a/wf_field/src/field.rs
+++ b/wf_field/src/field.rs
@@ -63,10 +63,8 @@ impl Field {
         s
     }
 
-    /**
-     * Gets the byte length of the unencoded field value
-     * @return the byte length of the unencoded field value
-     */
+    /// Gets the byte length of the unencoded field value
+    /// @return the byte length of the unencoded field value
     pub fn byte_length(&self) -> usize {
         if let Some(len) = self.definition.expected_byte_length() {
             return len;
@@ -75,10 +73,8 @@ impl Field {
         self.value.len()
     }
 
-    /**
-     * Gets the bit length of the encoded field
-     * @return the bit length of the compressed encoded field value
-     */
+    /// Gets the bit length of the encoded field
+    /// @return the bit length of the compressed encoded field value
     pub fn bit_length(&self) -> usize {
         return self
             .definition

--- a/wf_field/src/field.rs
+++ b/wf_field/src/field.rs
@@ -76,11 +76,10 @@ impl Field {
     /// Gets the bit length of the encoded field
     /// @return the bit length of the compressed encoded field value
     pub fn bit_length(&self) -> usize {
-        return self
-            .definition
+        self.definition
             .bytes
             .encoding
-            .convert_to_bit_length(self.byte_length());
+            .convert_to_bit_length(self.byte_length())
     }
 }
 

--- a/wf_field/src/field_definition.rs
+++ b/wf_field/src/field_definition.rs
@@ -67,11 +67,9 @@ impl FieldDefinition {
         }
     }
 
-    /**
-     * Sets the value of the message field if not already set
-     * @param data the data representing the field value
-     * @return TRUE if field value is set, FALSE if field already set or data is invalid
-     */
+    /// Sets the value of the message field if not already set
+    /// @param data the data representing the field value
+    /// @return TRUE if field value is set, FALSE if field already set or data is invalid
     pub fn set<T: AsRef<str> + Into<String>>(self, data: T) -> Result<Field, ValidationError> {
         self.validate(data.as_ref())?;
         Ok(Field::new(self, data.into()))
@@ -106,10 +104,8 @@ impl FieldDefinition {
         }
     }
 
-    /**
-     * Gets the bit length of the encoded field
-     * @return the bit length of the compressed encoded field value
-     */
+    /// Gets the bit length of the encoded field
+    /// @return the bit length of the compressed encoded field value
     pub fn bit_length(&self) -> usize {
         self.bytes
             .encoding

--- a/wf_field/src/field_definition.rs
+++ b/wf_field/src/field_definition.rs
@@ -111,14 +111,13 @@ impl FieldDefinition {
      * @return the bit length of the compressed encoded field value
      */
     pub fn bit_length(&self) -> usize {
-        return self
-            .bytes
+        self.bytes
             .encoding
-            .convert_to_bit_length(self.expected_byte_length().unwrap_or(0));
+            .convert_to_bit_length(self.expected_byte_length().unwrap_or(0))
     }
 }
 
-const NULL_FIELD_NAME: &'static str = "NULL FIELD NAME";
+const NULL_FIELD_NAME: &str = "NULL FIELD NAME";
 
 impl Validation for FieldDefinition {
     fn validate(&self, value: &str) -> Result<(), ValidationError> {

--- a/wf_field/src/field_definition_parser.rs
+++ b/wf_field/src/field_definition_parser.rs
@@ -30,9 +30,6 @@ impl<T: FieldDefinitionParser> FieldDefinitionParserBase for T {
     }
 
     fn parse_header(&mut self) -> Vec<Field> {
-        let definitions = definitions::header::DEFINITIONS;
-        let fields = self.parse_fields(definitions.to_vec());
-
-        fields
+        self.parse_fields(definitions::header::DEFINITIONS.to_vec())
     }
 }

--- a/wf_field/src/field_definition_parser.rs
+++ b/wf_field/src/field_definition_parser.rs
@@ -1,18 +1,20 @@
-use crate::{definitions, types::MessageType, Field, FieldDefinition, MessageHeaderOrder};
+use crate::{definitions, Field, FieldDefinition};
 
 pub trait FieldDefinitionParser {
+    /// uses FieldDefinition to extract the associated string value from data
     fn parse(&mut self, definition: &FieldDefinition) -> String;
     /// meant to calculate remaining values (if any) for request field definitions
     fn remaining(&self) -> usize;
 }
 
 pub trait FieldDefinitionParserBase {
+    /// parse multiple FieldDefinitions and extract its assoicated values and converts it into Fields
     fn parse_fields(&mut self, field_defs: Vec<FieldDefinition>) -> Vec<Field>;
+    /// parses header definitions into an array of Fields
     fn parse_header(&mut self) -> Vec<Field>;
 }
 
 impl<T: FieldDefinitionParser> FieldDefinitionParserBase for T {
-    /// parses array of field definitions from a data source into a Field
     fn parse_fields(&mut self, field_defs: Vec<FieldDefinition>) -> Vec<Field> {
         /* if self.data.len() < field_defs.len() {
             panic!("not enough field definitions to process given values\nvalues: {:#?}\ndefinitions: {:#?}", self.data, field_defs);

--- a/wf_field/src/lib.rs
+++ b/wf_field/src/lib.rs
@@ -28,11 +28,6 @@ pub use {
     types::MessageType,
 };
 
-pub const FIELD_PREFIX: &'static str = "Prefix";
-pub const FIELD_VERSION: &'static str = "Version";
-pub const FIELD_MESSAGETYPE: &'static str = "MessageCode";
-pub const FIELD_TESTMESSAGETYPE: &'static str = "PseudoMessageCode";
-
 pub trait FieldValue: AsRef<str> + Into<String> + std::fmt::Debug {}
 impl<T> FieldValue for T where T: AsRef<str> + Into<String> + std::fmt::Debug {}
 

--- a/wf_field/src/lib.rs
+++ b/wf_field/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 #[cfg(test)]
 mod codec_tests;
 

--- a/wf_field/src/lib.rs
+++ b/wf_field/src/lib.rs
@@ -5,6 +5,7 @@ mod codec_tests;
 mod validation_test;
 
 mod byte_configuration;
+#[allow(dead_code)]
 mod codec_positions;
 #[allow(dead_code)]
 pub mod definitions;

--- a/wf_field/src/types.rs
+++ b/wf_field/src/types.rs
@@ -58,99 +58,73 @@ impl MessageType {
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum MessageType {
-    /**
-     * Undefined message type
-     */
-    Any, //UNDEFINED
+    /// Undefined message type
+    Any,
 
-    /**
-     * Authentication message type
-     * <p> Message introducing the sender on the network with the sender’s authentication data
-     * @wfref 4.3.4 Management Messages: Authentication
-     */
-    Authentication, //("A", authenticationBodyFields),
+    /// Authentication message type
+    /// <p> Message introducing the sender on the network with the sender’s authentication data
+    /// @wfref 4.3.4 Management Messages: Authentication
+    Authentication,
 
-    /**
-     * Cryptographic message type
-     * <p> Message for management of keys and parameters of cryptographic functions
-     * @wfref 4.3.5 Management Messages: Cryptographic Support
-     */
-    Cryptographic, //("K", cryptoBodyFields),
+    /// Cryptographic message type
+    /// <p> Message for management of keys and parameters of cryptographic functions
+    /// @wfref 4.3.5 Management Messages: Cryptographic Support
+    Cryptographic,
 
-    /**
-     * Test message type
-     * <p> Message that can be used for testing Whiteflag functionality by applications
-     * @wfref 4.3.6 Management Messages: Test
-     */
-    Test, //("T", testBodyFields),
+    /// Test message type
+    /// <p> Message that can be used for testing Whiteflag functionality by applications
+    /// @wfref 4.3.6 Management Messages: Test
+    Test,
 
-    /**
-     * Resource message type
-     * <p> Message to point to an internet resource
-     * @wfref 4.3.2 Functional Messages: Resource
-     */
-    Resource, //("R", resourceBodyFields),
+    /// Resource message type
+    /// <p> Message to point to an internet resource
+    /// @wfref 4.3.2 Functional Messages: Resource
+    Resource,
 
-    /**
-     * Free Text message type
-     * <p> Message to send a free text string
-     * @wfref 4.3.3 Functional Messages: Free Text
-     */
-    FreeText, //("F", freetextBodyFields),
+    /// Free Text message type
+    /// <p> Message to send a free text string
+    /// @wfref 4.3.3 Functional Messages: Free Text
+    FreeText,
 
-    /**
-     * Protective Sign message type
-     * <p> Sign to mark objects under the protection of international law
-     * @wfref 4.3.1 Functional Messages: Signs/Signals
-     * @wfref 4.3.1.2.1 Protective Signs
-     */
-    Protective, //("P", signsignalBodyFields),
+    /// Protective Sign message type
+    /// <p> Sign to mark objects under the protection of international law
+    /// @wfref 4.3.1 Functional Messages: Signs/Signals
+    /// @wfref 4.3.1.2.1 Protective Signs
+    Protective,
 
-    /**
-     * Emergency Signal message type
-     * <p> Signal to send an emergency signal when in need of assistance
-     * @wfref 4.3.1 Functional Messages: Signs/Signals
-     * @wfref 4.3.1.2.2 Emergency Signals
-     */
-    Emergency, //("E", signsignalBodyFields),
+    /// Emergency Signal message type
+    /// <p> Signal to send an emergency signal when in need of assistance
+    /// @wfref 4.3.1 Functional Messages: Signs/Signals
+    /// @wfref 4.3.1.2.2 Emergency Signals
+    Emergency,
 
-    /**
-     * Danger Sign message type
-     * <p> Sign to mark a location or area of imminent danger, e.g. an area under attack, land mines, disaster, etc.
-     * @wfref 4.3.1 Functional Messages: Signs/Signals
-     * @wfref 4.3.1.2.3 Danger and Disaster Signs
-     */
-    Danger, //("D", signsignalBodyFields),
+    /// Danger Sign message type
+    /// <p> Sign to mark a location or area of imminent danger, e.g. an area under attack, land mines, disaster, etc.
+    /// @wfref 4.3.1 Functional Messages: Signs/Signals
+    /// @wfref 4.3.1.2.3 Danger and Disaster Signs
+    Danger,
 
-    /**
-     * Status Signal message type
-     * <p> Signal to provide the status of an object, or specifically for persons: give a proof of life
-     * @wfref 4.3.1 Functional Messages: Signs/Signals
-     * @wfref 4.3.1.2.4 Status Signals
-     */
-    Status, //("S", signsignalBodyFields),
+    /// Status Signal message type
+    /// <p> Signal to provide the status of an object, or specifically for persons: give a proof of life
+    /// @wfref 4.3.1 Functional Messages: Signs/Signals
+    /// @wfref 4.3.1.2.4 Status Signals
+    Status,
 
-    /**
-     * Infrastructure Sign message type
-     * <p> Sign to mark critical infrastructure, e.g. roads, utilities, water treatment, hospitals, power plants etc.
-     * @wfref 4.3.1 Functional Messages: Signs/Signals
-     * @wfref 4.3.1.2.5 Infrastructure Signs
-     */
-    Infrastructure, //("I", signsignalBodyFields),
+    /// Infrastructure Sign message type
+    /// <p> Sign to mark critical infrastructure, e.g. roads, utilities, water treatment, hospitals, power plants etc.
+    /// @wfref 4.3.1 Functional Messages: Signs/Signals
+    /// @wfref 4.3.1.2.5 Infrastructure Signs
+    Infrastructure,
 
-    /**
-     * Mission Signal message type
-     * <p> Signal to provide information on activities undertaken during a mission
-     * @wfref 4.3.1 Functional Messages: Signs/Signals
-     * @wfref 4.3.1.2.6 Mission Signals
-     */
-    Mission, //("M", signsignalBodyFields),
+    /// Mission Signal message type
+    /// <p> Signal to provide information on activities undertaken during a mission
+    /// @wfref 4.3.1 Functional Messages: Signs/Signals
+    /// @wfref 4.3.1.2.6 Mission Signals
+    Mission,
 
-    /**
-     * Request Signal message type
-     * <p> Signal to perform requests to other parties
-     * @wfref 4.3.1 Functional Messages: Signs/Signals
-     * @wfref 4.3.1.2.7 Request Signals
-     */
-    Request, //Q("Q", signsignalBodyFields);
+    /// Request Signal message type
+    /// <p> Signal to perform requests to other parties
+    /// @wfref 4.3.1 Functional Messages: Signs/Signals
+    /// @wfref 4.3.1.2.7 Request Signals
+    Request,
 }

--- a/wf_field/src/types.rs
+++ b/wf_field/src/types.rs
@@ -50,13 +50,13 @@ impl MessageType {
     pub fn get_message_code(code: &str) -> Self {
         Self::from_code(
             code.chars()
-                .nth(0)
+                .next()
                 .unwrap_or_else(|| panic!("invalid message code: {}", code)),
         )
     }
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum MessageType {
     /// Undefined message type
     Any,

--- a/wf_parser/src/header.rs
+++ b/wf_parser/src/header.rs
@@ -31,7 +31,7 @@ impl Header {
         parser: &mut T,
     ) -> Option<Field> {
         // if this is a test message, then we need to parse the pseudo code
-        if &self.code == &MessageType::Test {
+        if self.code == MessageType::Test {
             let def = definitions::test::PSEUDO_MESSAGE_CODE;
             let pseudo_code = parser.parse(&def);
             self.psuedo_code = Some(MessageType::get_message_code(&pseudo_code));

--- a/wf_validation/src/lib.rs
+++ b/wf_validation/src/lib.rs
@@ -3,7 +3,7 @@
 /// - [Encoding] invalid character set according to encoding
 /// - [FieldDefinition].{end_byte - start_byte} invalid length according to field definition
 /// - [FieldDefinition] invalid value according to field definition
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum ValidationError {
     #[error("{specification_level}\nunencoded byte length is invalid\nunencoded value: {data}\nexpected byte_length to be {expected_length} but was {}", .data.len())]
     InvalidLength {


### PR DESCRIPTION
### docs

A lot more docs were added to various important functions and examples were added for the two top level functions. Not every function is covered by documentation, but I will continue adding them as I find time.

### clippy

The easy clippy suggestions were knocked out. The only ones remaining relate to reductions in the math or logic of buffer functions in `wf_common`. I would like to handle those in a separate PR.