### PR TITLE
Clippy improves algorithms

### DIFF
--- a/src/wf_core/message.rs
+++ b/src/wf_core/message.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use super::{
     crypted_buffer::{CryptMode, CryptedBuffer},
     segment::MessageSegment,
@@ -105,7 +107,7 @@ impl Message {
     ) -> WhiteflagBuffer {
         let encryption_indicator_index = 2_usize;
         let encryption_indicator = &self.header[encryption_indicator_index]; // the encryption indicator is the 3rd index in the header
-        let method = WhiteflagEncryptionMethod::from_str(&encryption_indicator.get()).unwrap();
+        let method = WhiteflagEncryptionMethod::from_str(encryption_indicator.get()).unwrap();
         let encoded: WhiteflagBuffer = self.encode().into();
 
         match method {

--- a/wf_buffer/src/decode.rs
+++ b/wf_buffer/src/decode.rs
@@ -39,7 +39,7 @@ impl WhiteflagBuffer {
             field_bit_length
         } else {
             let mut bit_length = self.bit_length - start_bit;
-            bit_length -= bit_length % &definition.bytes.encoding.bit_length;
+            bit_length -= bit_length % definition.bytes.encoding.bit_length;
             bit_length
         };
 

--- a/wf_common/src/common.rs
+++ b/wf_common/src/common.rs
@@ -67,8 +67,8 @@ pub fn shift_right(buffer: &[u8], shift: isize) -> Vec<u8> {
 
     for i in (1..length).rev() {
         let b = &buffer[i - 1];
-        new_buffer[i] |= (0xFF & b & mask) << (BYTE - modulate);
-        new_buffer[i - 1] = (0xFF & b) >> modulate;
+        new_buffer[i] |= (b & mask) << (BYTE - modulate);
+        new_buffer[i - 1] = b >> modulate;
     }
 
     new_buffer
@@ -92,9 +92,9 @@ pub fn shift_left(buffer: &[u8], shift: isize) -> Vec<u8> {
     let mut new_buffer = vec![0; length];
 
     for i in 0..length {
-        new_buffer[i] = (0xFF & buffer[i]) << modulate;
+        new_buffer[i] = buffer[i] << modulate;
         if i < length - 1 {
-            new_buffer[i] |= (0xFF & buffer[i + 1] & mask) >> (BYTE - modulate);
+            new_buffer[i] |= (buffer[i + 1] & mask) >> (BYTE - modulate);
         }
     }
 
@@ -124,13 +124,12 @@ pub fn extract_bits(
     let mut new_byte_array: Vec<u8> = vec![0; byte_length];
     if shift == 0 {
         /* Faster loop if no shift needed */
-        for byte_index in 0..byte_length {
-            new_byte_array[byte_index] = buffer[start_byte + byte_index];
-        }
+        new_byte_array[..byte_length]
+            .copy_from_slice(&buffer[start_byte..(byte_length + start_byte)]);
     } else {
         /* Loop through bytes to shift */
         for byte_index in 0..byte_length {
-            new_byte_array[byte_index] = (0xFF & buffer[start_byte + byte_index]) << shift;
+            new_byte_array[byte_index] = buffer[start_byte + byte_index] << shift;
         }
 
         let end_byte = if byte_length < (buffer.len() - start_byte) {
@@ -141,7 +140,7 @@ pub fn extract_bits(
 
         for byte_index in 0..end_byte {
             new_byte_array[byte_index] |=
-                (0xFF & buffer[start_byte + byte_index + 1] & mask) >> (BYTE - shift);
+                (buffer[start_byte + byte_index + 1] & mask) >> (BYTE - shift);
         }
     }
 
@@ -225,7 +224,11 @@ pub fn concatinate_bits(
     /* Add the rest of the second byte array */
     let end_byte_2 = start_byte_2 + byte_length - byte_cursor;
 
-    for item in byte_array_2_shift.into_iter().take(end_byte_2).skip(start_byte_2) {
+    for item in byte_array_2_shift
+        .into_iter()
+        .take(end_byte_2)
+        .skip(start_byte_2)
+    {
         new_byte_array[byte_cursor] = item;
         byte_cursor += 1;
     }

--- a/wf_common/src/common.rs
+++ b/wf_common/src/common.rs
@@ -19,7 +19,7 @@ pub fn remove_hexadecimal_prefix(data: &str) -> &str {
 /// java equivalent: WfBinaryBuffer.byteLength
 pub fn byte_length(bit_length: usize) -> usize {
     let i_byte = BYTE;
-    (bit_length / i_byte) + (if (bit_length % i_byte) > 0 { 1 } else { 0 })
+    (bit_length / i_byte) + usize::from((bit_length % i_byte) > 0)
 }
 
 /// Shortens the byte array to fit the length of the used bits
@@ -205,12 +205,12 @@ pub fn concatinate_bits(
     let byte_array_2_shift = shift_right(byte_array_2, shift as isize);
     let mut new_byte_array = vec![0; byte_length as usize];
 
-    /* Concatination */
+    /* Concatenation */
     let mut byte_cursor = 0;
     let mut start_byte_2 = 0;
     if byte_length_1 != 0 {
         /* Add first byte array */
-        for byte_index in 0..byte_length_1 {
+        for (byte_index, _) in byte_array_1.iter().enumerate().take(byte_length_1) {
             byte_cursor = byte_index;
             new_byte_array[byte_cursor] = byte_array_1[byte_index];
         }
@@ -225,8 +225,8 @@ pub fn concatinate_bits(
     /* Add the rest of the second byte array */
     let end_byte_2 = start_byte_2 + byte_length - byte_cursor;
 
-    for byte_index in start_byte_2..end_byte_2 {
-        new_byte_array[byte_cursor] = byte_array_2_shift[byte_index];
+    for item in byte_array_2_shift.into_iter().take(end_byte_2).skip(start_byte_2) {
+        new_byte_array[byte_cursor] = item;
         byte_cursor += 1;
     }
 

--- a/wf_crypto/src/encryption_method.rs
+++ b/wf_crypto/src/encryption_method.rs
@@ -37,12 +37,16 @@ pub enum WhiteflagEncryptionMethod {
     Aes512IegPsk,
 }
 
-impl WhiteflagEncryptionMethod {
-    pub fn from_str(number: &str) -> CryptoResult<Self> {
-        let n = number.parse::<usize>().unwrap();
+impl std::str::FromStr for WhiteflagEncryptionMethod {
+    type Err = CryptoError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let n = s.parse::<usize>().unwrap();
         Self::from_number(n)
     }
+}
 
+impl WhiteflagEncryptionMethod {
     pub fn from_number(number: usize) -> CryptoResult<Self> {
         let method = match number {
             0 => Self::NoEncryption,

--- a/wf_field/src/field.rs
+++ b/wf_field/src/field.rs
@@ -95,8 +95,8 @@ impl AsRef<String> for Field {
     }
 }
 
-impl Into<String> for Field {
-    fn into(self) -> String {
-        self.value
+impl From<Field> for String {
+    fn from(f: Field) -> Self {
+        f.value
     }
 }

--- a/wf_field/src/request.rs
+++ b/wf_field/src/request.rs
@@ -24,7 +24,7 @@ pub fn create_request_fields<T: FieldDefinitionParser>(parser: &mut T) -> Vec<Fi
 
     (0..(n.mul(2)))
         .step_by(2)
-        .map(|i| {
+        .flat_map(|i| {
             let n_field = (i / 2) + 1;
             let byte_start = start_byte;
             let byte_split = byte_start + ot_size;
@@ -49,6 +49,5 @@ pub fn create_request_fields<T: FieldDefinitionParser>(parser: &mut T) -> Vec<Fi
                 Field::new_with_name(parser.parse(&oq), format!("{}{}Quant", name, n_field), oq),
             ]
         })
-        .flatten()
         .collect()
 }


### PR DESCRIPTION
`cargo clippy` suggested that the identity operations `0xFF & ...` be removed. Both @Romulus10 and I believe there may have been a reason for including those operations due to java being a higher level language than rust.